### PR TITLE
Expand RunnerType to cover all currently available GitHub-hosted runners

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/RunnerType.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/RunnerType.kt
@@ -1,5 +1,25 @@
 package it.krzeminski.githubactions.domain
 
+/**
+ * Types of GitHub-hosted runners available. Should be kept in sync with the official list at
+ * https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+ */
 enum class RunnerType {
+    // "Latest" labels
     UbuntuLatest,
+    WindowsLatest,
+    MacOSLatest,
+
+    // Windows runners
+    Windows2022,
+    Windows2019,
+    Windows2016,
+
+    // Ubuntu runners
+    Ubuntu2004,
+    Ubuntu1804,
+
+    // macOS runners
+    MacOS11,
+    MacOS1015,
 }

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -7,7 +7,16 @@ import it.krzeminski.githubactions.domain.CommandStep
 import it.krzeminski.githubactions.domain.ExternalActionStep
 import it.krzeminski.githubactions.domain.Job
 import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.RunnerType.MacOS1015
+import it.krzeminski.githubactions.domain.RunnerType.MacOS11
+import it.krzeminski.githubactions.domain.RunnerType.MacOSLatest
+import it.krzeminski.githubactions.domain.RunnerType.Ubuntu1804
+import it.krzeminski.githubactions.domain.RunnerType.Ubuntu2004
 import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.RunnerType.Windows2016
+import it.krzeminski.githubactions.domain.RunnerType.Windows2019
+import it.krzeminski.githubactions.domain.RunnerType.Windows2022
+import it.krzeminski.githubactions.domain.RunnerType.WindowsLatest
 import it.krzeminski.githubactions.domain.Step
 import it.krzeminski.githubactions.domain.Trigger
 import it.krzeminski.githubactions.domain.Workflow
@@ -112,4 +121,13 @@ fun List<Step>.toYaml() =
 fun RunnerType.toYaml() =
     when (this) {
         UbuntuLatest -> "ubuntu-latest"
+        WindowsLatest -> "windows-latest"
+        MacOSLatest -> "macos-latest"
+        Windows2022 -> "windows-2022"
+        Windows2019 -> "windows-2019"
+        Windows2016 -> "windows-2016"
+        Ubuntu2004 -> "ubuntu-20.04"
+        Ubuntu1804 -> "ubuntu-18.04"
+        MacOS11 -> "macos-11"
+        MacOS1015 -> "macos-10.15"
     }

--- a/library/src/test/kotlin/it/krzeminski/githubactions/EndToEndTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/EndToEndTest.kt
@@ -164,4 +164,57 @@ class EndToEndTest : FunSpec({
                 strategy: {}
         """.trimIndent()
     }
+
+    test("Using a windows-2022 runner") {
+        // given
+        val targetTempFile = tempfile()
+        val workflowWithTempTargetFile = workflow(
+            name = "Test workflow",
+            on = listOf(Trigger.Push),
+            sourceFile = sourceFile.toPath(),
+            targetFile = targetTempFile.toPath(),
+        ) {
+            job(
+                name = "test_job",
+                runsOn = RunnerType.Windows2022,
+            ) {
+                uses(
+                    name = "Check out",
+                    action = Checkout(),
+                )
+
+                run(
+                    name = "Hello world!",
+                    command = "echo 'hello!'",
+                )
+            }
+        }
+
+        // when
+        workflowWithTempTargetFile.writeToFile()
+
+        // then
+        targetTempFile.readText() shouldBe """
+            # This file was generated using Kotlin DSL (${sourceFile.path}).
+            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+            
+            name: "Test workflow"
+            on:
+              push: {}
+            jobs:
+              "test_job":
+                runs-on: "windows-2022"
+                steps:
+                - 
+                  uses: "actions/checkout@v2"
+                  with:
+                    
+                    fetch-depth: 1
+                - 
+                  name: "Hello world!"
+                  run: "echo 'hello!'"
+                needs: []
+                strategy: {}
+        """.trimIndent()
+    }
 })


### PR DESCRIPTION
GitHub provides a fairly large set of runners [hosted by them](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) which are available for users, this PR simply adds all of these runners into the library.

GitHub also provides the ability to have [self-hosted runners](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-self-hosted-runners) which use an array of stringly-typed labels to identify the correct machine to run the job on. This would require a fairly major rework of the API which I can propose in a separate issue if there's interest in supporting the use-case.
