### PR TITLE
[#67] Make 'sourceFile' and 'targetFile' plain strings

### DIFF
--- a/examples/src/main/kotlin/HelloWorld.kt
+++ b/examples/src/main/kotlin/HelloWorld.kt
@@ -3,14 +3,13 @@ import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.triggers.Push
 import it.krzeminski.githubactions.dsl.workflow
 import it.krzeminski.githubactions.yaml.toYaml
-import java.nio.file.Paths
 
 fun main() {
     val workflow = workflow(
         name = "Test workflow",
         on = listOf(Push()),
-        sourceFile = Paths.get("script.main.kts"),
-        targetFile = Paths.get("some_workflow.yaml"),
+        sourceFile = "script.main.kts",
+        targetFile = "some_workflow.yaml",
     ) {
         job(
             name = "test_job",

--- a/examples/src/main/kotlin/KotlinPytonGenerateReports.kt
+++ b/examples/src/main/kotlin/KotlinPytonGenerateReports.kt
@@ -12,8 +12,8 @@ fun main() {
     val workflow = workflow(
         name = "Generate reports",
         on = listOf(WorkflowDispatch()),
-        sourceFile = Paths.get("script.main.kts"),
-        targetFile = Paths.get("some_workflow.yaml"),
+        sourceFile = "script.main.kts",
+        targetFile = "some_workflow.yaml",
     ) {
         val generateReports = job(
             name = "generate_reports",

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
@@ -1,13 +1,12 @@
 package it.krzeminski.githubactions.domain
 
 import it.krzeminski.githubactions.domain.triggers.Trigger
-import java.nio.file.Path
 
 data class Workflow(
     val name: String,
     val on: List<Trigger>,
     val env: LinkedHashMap<String, String>,
-    val sourceFile: Path,
-    val targetFile: Path,
+    val sourceFile: String,
+    val targetFile: String,
     val jobs: List<Job>,
 )

--- a/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
@@ -4,15 +4,14 @@ import it.krzeminski.githubactions.domain.Job
 import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Trigger
-import java.nio.file.Path
 
 @GithubActionsDsl
 class WorkflowBuilder(
     name: String,
     on: List<Trigger>,
     env: LinkedHashMap<String, String> = linkedMapOf(),
-    sourceFile: Path,
-    targetFile: Path,
+    sourceFile: String,
+    targetFile: String,
     jobs: List<Job> = emptyList(),
 ) {
     private var workflow = Workflow(
@@ -65,8 +64,8 @@ fun workflow(
     name: String,
     on: List<Trigger>,
     env: LinkedHashMap<String, String> = linkedMapOf(),
-    sourceFile: Path,
-    targetFile: Path,
+    sourceFile: String,
+    targetFile: String,
     block: WorkflowBuilder.() -> Unit,
 ): Workflow {
     val workflowBuilder = WorkflowBuilder(

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -4,6 +4,7 @@ import it.krzeminski.githubactions.actions.actions.CheckoutV2
 import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.dsl.toBuilder
+import java.nio.file.Paths
 
 fun Workflow.toYaml(addConsistencyCheck: Boolean = true): String {
     val jobsWithConsistencyCheck = if (addConsistencyCheck) {
@@ -53,5 +54,5 @@ fun Workflow.writeToFile() {
         // Because the current consistency check logic relies on writing to standard output.
         addConsistencyCheck = false,
     )
-    this.targetFile.toFile().writeText(yaml)
+    Paths.get(this.targetFile).toFile().writeText(yaml)
 }

--- a/library/src/test/kotlin/it/krzeminski/githubactions/EndToEndTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/EndToEndTest.kt
@@ -9,7 +9,6 @@ import it.krzeminski.githubactions.domain.triggers.Push
 import it.krzeminski.githubactions.dsl.workflow
 import it.krzeminski.githubactions.yaml.toYaml
 import it.krzeminski.githubactions.yaml.writeToFile
-import java.nio.file.Paths
 
 class EndToEndTest : FunSpec({
     val sourceFile = tempfile().also {
@@ -18,8 +17,8 @@ class EndToEndTest : FunSpec({
     val workflow = workflow(
         name = "Test workflow",
         on = listOf(Push()),
-        sourceFile = sourceFile.toPath(),
-        targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+        sourceFile = sourceFile.path,
+        targetFile = ".github/workflows/some_workflow.yaml",
     ) {
         job(
             name = "test_job",
@@ -79,8 +78,8 @@ class EndToEndTest : FunSpec({
         val workflowWithDependency = workflow(
             name = "Test workflow",
             on = listOf(Push()),
-            sourceFile = sourceFile.toPath(),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+            sourceFile = sourceFile.path,
+            targetFile = ".github/workflows/some_workflow.yaml",
         ) {
             val testJob1 = job(
                 name = "test_job_1",
@@ -177,8 +176,8 @@ class EndToEndTest : FunSpec({
         val workflowWithMultilineCommand = workflow(
             name = "Test workflow",
             on = listOf(Push()),
-            sourceFile = sourceFile.toPath(),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+            sourceFile = sourceFile.path,
+            targetFile = ".github/workflows/some_workflow.yaml",
         ) {
             job(
                 name = "test_job",
@@ -229,8 +228,8 @@ class EndToEndTest : FunSpec({
         val workflowWithTempTargetFile = workflow(
             name = "Test workflow",
             on = listOf(Push()),
-            sourceFile = sourceFile.toPath(),
-            targetFile = targetTempFile.toPath(),
+            sourceFile = sourceFile.path,
+            targetFile = targetTempFile.path,
         ) {
             job(
                 name = "test_job",
@@ -278,8 +277,8 @@ class EndToEndTest : FunSpec({
         val actualYaml = workflow(
             name = "Test workflow",
             on = listOf(Push()),
-            sourceFile = sourceFile.toPath(),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+            sourceFile = sourceFile.path,
+            targetFile = ".github/workflows/some_workflow.yaml",
         ) {
             job(
                 name = "test_job",
@@ -327,8 +326,8 @@ class EndToEndTest : FunSpec({
                     hello! workflow
                 """.trimIndent()
             ),
-            sourceFile = sourceFile.toPath(),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+            sourceFile = sourceFile.path,
+            targetFile = ".github/workflows/some_workflow.yaml",
         ) {
             job(
                 name = "test_job",


### PR DESCRIPTION
The paths are used to generate a consistency check which runs on Linux.
The goal here is to avoid having any OS-specific logic. It's simpler to
ask for the paths as strings rather than use `Path`, the library
doesn't really make use of the features that `Path` gives.