### PR TITLE
Fix for add-and-commit

### DIFF
--- a/library/src/gen/kotlin/it/krzeminski/githubactions/actions/endbug/AddAndCommitV8.kt
+++ b/library/src/gen/kotlin/it/krzeminski/githubactions/actions/endbug/AddAndCommitV8.kt
@@ -4,7 +4,6 @@
 package it.krzeminski.githubactions.actions.endbug
 
 import it.krzeminski.githubactions.actions.Action
-import kotlin.Boolean
 import kotlin.String
 import kotlin.Suppress
 
@@ -69,7 +68,7 @@ public class AddAndCommitV8(
      * Whether to push the commit and, if any, its tags to the repo. It can also be used to set the
      * git push arguments (more info in the README)
      */
-    public val push: Boolean? = null,
+    public val push: String? = null,
     /**
      * Arguments for the git rm command
      */
@@ -100,7 +99,7 @@ public class AddAndCommitV8(
             newBranch?.let { "new_branch" to it },
             pathspecErrorHandling?.let { "pathspec_error_handling" to it.stringValue },
             pull?.let { "pull" to it },
-            push?.let { "push" to it.toString() },
+            push?.let { "push" to it },
             remove?.let { "remove" to it },
             tag?.let { "tag" to it },
             githubToken?.let { "github_token" to it },

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
@@ -74,7 +74,6 @@ val wrappersToGenerate = listOf(
         mapOf(
             "default_author" to EnumTyping("DefaultActor", listOf("github_actor", "user_info", "github_actions")),
             "pathspec_error_handling" to EnumTyping("PathSpecErrorHandling", listOf("ignore", "exitImmediately", "exitAtEnd")),
-            "push" to BooleanTyping,
         )
     ),
 


### PR DESCRIPTION
The value for "push" can be true/false, but it can also be something like "--force --set-upstream origin dependency-update" which is passed as an argument for git push