### PR TITLE
Generate wrapper for actions/setup-python

### DIFF
--- a/library/src/gen/kotlin/it/krzeminski/githubactions/actions/actions/SetupPythonV2.kt
+++ b/library/src/gen/kotlin/it/krzeminski/githubactions/actions/actions/SetupPythonV2.kt
@@ -48,7 +48,7 @@ public class SetupPythonV2(
             cache?.let { "cache" to it.stringValue },
             architecture?.let { "architecture" to it.stringValue },
             token?.let { "token" to it },
-            cacheDependencyPath?.let { "cache-dependency-path" to it.joinToString(" ") },
+            cacheDependencyPath?.let { "cache-dependency-path" to it.joinToString("\n") },
         ).toTypedArray()
     )
 

--- a/library/src/gen/kotlin/it/krzeminski/githubactions/actions/actions/SetupPythonV2.kt
+++ b/library/src/gen/kotlin/it/krzeminski/githubactions/actions/actions/SetupPythonV2.kt
@@ -1,0 +1,78 @@
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
+// be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
+// generator itself.
+package it.krzeminski.githubactions.actions.actions
+
+import it.krzeminski.githubactions.actions.Action
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+
+/**
+ * Action: Setup Python
+ *
+ * Set up a specific version of Python and add the command-line tools to the PATH.
+ *
+ * [Action on GitHub](https://github.com/actions/setup-python)
+ */
+public class SetupPythonV2(
+    /**
+     * Version range or exact version of a Python version to use, using SemVer's version range
+     * syntax.
+     */
+    public val pythonVersion: String? = null,
+    /**
+     * Used to specify a package manager for caching in the default directory. Supported values:
+     * pip, pipenv.
+     */
+    public val cache: SetupPythonV2.PackageManager? = null,
+    /**
+     * The target architecture (x86, x64) of the Python interpreter.
+     */
+    public val architecture: SetupPythonV2.Architecture? = null,
+    /**
+     * Used to pull python distributions from actions/python-versions. Since there's a default, this
+     * is typically not supplied by the user.
+     */
+    public val token: String? = null,
+    /**
+     * Used to specify the path to dependency files. Supports wildcards or a list of file names for
+     * caching multiple dependencies.
+     */
+    public val cacheDependencyPath: List<String>? = null
+) : Action("actions", "setup-python", "v2") {
+    @Suppress("SpreadOperator")
+    public override fun toYamlArguments() = linkedMapOf(
+        *listOfNotNull(
+            pythonVersion?.let { "python-version" to it },
+            cache?.let { "cache" to it.stringValue },
+            architecture?.let { "architecture" to it.stringValue },
+            token?.let { "token" to it },
+            cacheDependencyPath?.let { "cache-dependency-path" to it.joinToString(" ") },
+        ).toTypedArray()
+    )
+
+    public sealed class PackageManager(
+        public val stringValue: String
+    ) {
+        public object Pip : SetupPythonV2.PackageManager("pip")
+
+        public object Pipenv : SetupPythonV2.PackageManager("pipenv")
+
+        public class Custom(
+            customStringValue: String
+        ) : SetupPythonV2.PackageManager(customStringValue)
+    }
+
+    public sealed class Architecture(
+        public val stringValue: String
+    ) {
+        public object X64 : SetupPythonV2.Architecture("x64")
+
+        public object X86 : SetupPythonV2.Architecture("x86")
+
+        public class Custom(
+            customStringValue: String
+        ) : SetupPythonV2.Architecture(customStringValue)
+    }
+}

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
@@ -7,18 +7,6 @@ fun main() {
     // To ensure there are no leftovers from previous generations.
     Paths.get("library/src/gen").toFile().deleteRecursively()
 
-    val wrappersNames = wrappersToGenerate.map {  (actionCoords, _) ->
-        "${actionCoords.owner}/${actionCoords.name}".toLowerCase()
-    }
-    val wrappersNamesSorted = wrappersNames.sorted()
-    if (wrappersNames != wrappersNamesSorted) {
-        error("""
-            Please keep the wrappers sorted to minimize merge conflicts.
-            Expected: $wrappersNamesSorted
-            Actual:   $wrappersNames
-            """.trimIndent())
-    }
-
     wrappersToGenerate.forEach { (actionCoords, inputTypings) ->
         println("Generating ${actionCoords.owner}/${actionCoords.name}@${actionCoords.version}...")
         val (code, path) = actionCoords.generateWrapper(inputTypings)

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
@@ -7,6 +7,18 @@ fun main() {
     // To ensure there are no leftovers from previous generations.
     Paths.get("library/src/gen").toFile().deleteRecursively()
 
+    val wrappersNames = wrappersToGenerate.map {  (actionCoords, _) ->
+        "${actionCoords.owner}/${actionCoords.name}".toLowerCase()
+    }
+    val wrappersNamesSorted = wrappersNames.sorted()
+    if (wrappersNames != wrappersNamesSorted) {
+        error("""
+            Please keep the wrappers sorted to minimize merge conflicts.
+            Expected: $wrappersNamesSorted
+            Actual:   $wrappersNames
+            """.trimIndent())
+    }
+
     wrappersToGenerate.forEach { (actionCoords, inputTypings) ->
         println("Generating ${actionCoords.owner}/${actionCoords.name}@${actionCoords.version}...")
         val (code, path) = actionCoords.generateWrapper(inputTypings)

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
@@ -136,4 +136,13 @@ val wrappersToGenerate = listOf(
             "docker_heroku_process_type" to EnumTyping("HerokuProcessType", listOf("web", "worker")),
         )
     ),
+
+    WrapperRequest(
+        ActionCoords("actions", "setup-python", "v2"),
+        mapOf(
+            "cache" to EnumTyping("PackageManager", listOf("pip", "pipenv")),
+            "architecture" to EnumTyping("Architecture", listOf("x64", "x86")),
+            "cache-dependency-path" to ListOfStringsTyping(" "),
+        )
+    ),
 )

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
@@ -9,8 +9,6 @@ import it.krzeminski.githubactions.wrappergenerator.domain.typings.IntegerWithSp
 import it.krzeminski.githubactions.wrappergenerator.domain.typings.ListOfStringsTyping
 
 val wrappersToGenerate = listOf(
-    // Please keep the wrapper requests sorted ("actions/checkout" before "gradle/build-action")
-    // in order to minimize merge conflicts
     WrapperRequest(
         ActionCoords("actions", "checkout", "v2"),
         mapOf(
@@ -47,7 +45,6 @@ val wrappersToGenerate = listOf(
             "cache" to EnumTyping("BuildPlatform", listOf("maven", "gradle")),
         ),
     ),
-
     WrapperRequest(
         ActionCoords("actions", "setup-node", "v2"),
         mapOf(
@@ -62,7 +59,7 @@ val wrappersToGenerate = listOf(
         mapOf(
             "cache" to EnumTyping("PackageManager", listOf("pip", "pipenv")),
             "architecture" to EnumTyping("Architecture", listOf("x64", "x86")),
-            "cache-dependency-path" to ListOfStringsTyping(" "),
+            "cache-dependency-path" to ListOfStringsTyping("\\n"),
         )
     ),
     WrapperRequest(
@@ -79,18 +76,7 @@ val wrappersToGenerate = listOf(
             )
         ),
     ),
-    WrapperRequest(
-        ActionCoords("AkhileshNS", "heroku-deploy", "v3.12.12"),
-        mapOf(
-            "dontuseforce" to BooleanTyping,
-            "dontautocreate" to BooleanTyping,
-            "usedocker" to BooleanTyping,
-            "delay"  to IntegerTyping,
-            "rollbackonhealthcheckfailed" to BooleanTyping,
-            "justlogin" to BooleanTyping,
-            "docker_heroku_process_type" to EnumTyping("HerokuProcessType", listOf("web", "worker")),
-        )
-    ),
+
     WrapperRequest(
         ActionCoords("EndBug", "add-and-commit", "v8"),
         mapOf(
@@ -98,17 +84,11 @@ val wrappersToGenerate = listOf(
             "pathspec_error_handling" to EnumTyping("PathSpecErrorHandling", listOf("ignore", "exitImmediately", "exitAtEnd")),
         )
     ),
-    WrapperRequest(
-        ActionCoords("gradle-update", "update-gradle-wrapper-action", "v1"),
-        mapOf(
-            "reviewers" to ListOfStringsTyping(","),
-            "team-reviewers" to ListOfStringsTyping(","),
-            "labels" to ListOfStringsTyping(","),
-            "set-distribution-checksum" to BooleanTyping,
-            "paths" to ListOfStringsTyping(","),
-            "paths-ignore" to ListOfStringsTyping(","),
-        ),
-    ),
+
+    WrapperRequest(ActionCoords("madhead", "check-gradle-version", "v1")),
+    WrapperRequest(ActionCoords("madhead", "read-java-properties", "latest"), mapOf("all" to BooleanTyping)),
+    WrapperRequest(ActionCoords("madhead", "semver-utils", "latest")),
+
     WrapperRequest(
         ActionCoords("gradle", "gradle-build-action", "v2"),
         mapOf(
@@ -126,9 +106,19 @@ val wrappersToGenerate = listOf(
             "allow-checksums" to ListOfStringsTyping(","),
         ),
     ),
-    WrapperRequest(ActionCoords("madhead", "check-gradle-version", "v1")),
-    WrapperRequest(ActionCoords("madhead", "read-java-properties", "latest"), mapOf("all" to BooleanTyping)),
-    WrapperRequest(ActionCoords("madhead", "semver-utils", "latest")),
+
+    WrapperRequest(
+        ActionCoords("gradle-update", "update-gradle-wrapper-action", "v1"),
+        mapOf(
+            "reviewers" to ListOfStringsTyping(","),
+            "team-reviewers" to ListOfStringsTyping(","),
+            "labels" to ListOfStringsTyping(","),
+            "set-distribution-checksum" to BooleanTyping,
+            "paths" to ListOfStringsTyping(","),
+            "paths-ignore" to ListOfStringsTyping(","),
+        ),
+    ),
+
     WrapperRequest(ActionCoords("peterjgrainger", "action-create-branch", "v2.1.0")),
 
     WrapperRequest(
@@ -141,6 +131,17 @@ val wrappersToGenerate = listOf(
             "pr_allow_empty" to BooleanTyping,
         ),
     ),
-    // Please keep the wrapper requests sorted ("actions/checkout" before "gradle/build-action")
-    // in order to minimize merge conflicts
+
+    WrapperRequest(
+        ActionCoords("AkhileshNS", "heroku-deploy", "v3.12.12"),
+        mapOf(
+            "dontuseforce" to BooleanTyping,
+            "dontautocreate" to BooleanTyping,
+            "usedocker" to BooleanTyping,
+            "delay"  to IntegerTyping,
+            "rollbackonhealthcheckfailed" to BooleanTyping,
+            "justlogin" to BooleanTyping,
+            "docker_heroku_process_type" to EnumTyping("HerokuProcessType", listOf("web", "worker")),
+        )
+    ),
 )

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
@@ -9,6 +9,8 @@ import it.krzeminski.githubactions.wrappergenerator.domain.typings.IntegerWithSp
 import it.krzeminski.githubactions.wrappergenerator.domain.typings.ListOfStringsTyping
 
 val wrappersToGenerate = listOf(
+    // Please keep the wrapper requests sorted ("actions/checkout" before "gradle/build-action")
+    // in order to minimize merge conflicts
     WrapperRequest(
         ActionCoords("actions", "checkout", "v2"),
         mapOf(
@@ -45,6 +47,7 @@ val wrappersToGenerate = listOf(
             "cache" to EnumTyping("BuildPlatform", listOf("maven", "gradle")),
         ),
     ),
+
     WrapperRequest(
         ActionCoords("actions", "setup-node", "v2"),
         mapOf(
@@ -53,6 +56,14 @@ val wrappersToGenerate = listOf(
             "cache" to EnumTyping("PackageManager", listOf("npm", "yarn", "pnpm")),
             "cache-dependency-path" to ListOfStringsTyping("\\n"),
         ),
+    ),
+    WrapperRequest(
+        ActionCoords("actions", "setup-python", "v2"),
+        mapOf(
+            "cache" to EnumTyping("PackageManager", listOf("pip", "pipenv")),
+            "architecture" to EnumTyping("Architecture", listOf("x64", "x86")),
+            "cache-dependency-path" to ListOfStringsTyping(" "),
+        )
     ),
     WrapperRequest(
         ActionCoords("actions", "upload-artifact", "v2"),
@@ -68,7 +79,18 @@ val wrappersToGenerate = listOf(
             )
         ),
     ),
-
+    WrapperRequest(
+        ActionCoords("AkhileshNS", "heroku-deploy", "v3.12.12"),
+        mapOf(
+            "dontuseforce" to BooleanTyping,
+            "dontautocreate" to BooleanTyping,
+            "usedocker" to BooleanTyping,
+            "delay"  to IntegerTyping,
+            "rollbackonhealthcheckfailed" to BooleanTyping,
+            "justlogin" to BooleanTyping,
+            "docker_heroku_process_type" to EnumTyping("HerokuProcessType", listOf("web", "worker")),
+        )
+    ),
     WrapperRequest(
         ActionCoords("EndBug", "add-and-commit", "v8"),
         mapOf(
@@ -76,11 +98,17 @@ val wrappersToGenerate = listOf(
             "pathspec_error_handling" to EnumTyping("PathSpecErrorHandling", listOf("ignore", "exitImmediately", "exitAtEnd")),
         )
     ),
-
-    WrapperRequest(ActionCoords("madhead", "check-gradle-version", "v1")),
-    WrapperRequest(ActionCoords("madhead", "read-java-properties", "latest"), mapOf("all" to BooleanTyping)),
-    WrapperRequest(ActionCoords("madhead", "semver-utils", "latest")),
-
+    WrapperRequest(
+        ActionCoords("gradle-update", "update-gradle-wrapper-action", "v1"),
+        mapOf(
+            "reviewers" to ListOfStringsTyping(","),
+            "team-reviewers" to ListOfStringsTyping(","),
+            "labels" to ListOfStringsTyping(","),
+            "set-distribution-checksum" to BooleanTyping,
+            "paths" to ListOfStringsTyping(","),
+            "paths-ignore" to ListOfStringsTyping(","),
+        ),
+    ),
     WrapperRequest(
         ActionCoords("gradle", "gradle-build-action", "v2"),
         mapOf(
@@ -98,19 +126,9 @@ val wrappersToGenerate = listOf(
             "allow-checksums" to ListOfStringsTyping(","),
         ),
     ),
-
-    WrapperRequest(
-        ActionCoords("gradle-update", "update-gradle-wrapper-action", "v1"),
-        mapOf(
-            "reviewers" to ListOfStringsTyping(","),
-            "team-reviewers" to ListOfStringsTyping(","),
-            "labels" to ListOfStringsTyping(","),
-            "set-distribution-checksum" to BooleanTyping,
-            "paths" to ListOfStringsTyping(","),
-            "paths-ignore" to ListOfStringsTyping(","),
-        ),
-    ),
-
+    WrapperRequest(ActionCoords("madhead", "check-gradle-version", "v1")),
+    WrapperRequest(ActionCoords("madhead", "read-java-properties", "latest"), mapOf("all" to BooleanTyping)),
+    WrapperRequest(ActionCoords("madhead", "semver-utils", "latest")),
     WrapperRequest(ActionCoords("peterjgrainger", "action-create-branch", "v2.1.0")),
 
     WrapperRequest(
@@ -123,26 +141,6 @@ val wrappersToGenerate = listOf(
             "pr_allow_empty" to BooleanTyping,
         ),
     ),
-
-    WrapperRequest(
-        ActionCoords("AkhileshNS", "heroku-deploy", "v3.12.12"),
-        mapOf(
-            "dontuseforce" to BooleanTyping,
-            "dontautocreate" to BooleanTyping,
-            "usedocker" to BooleanTyping,
-            "delay"  to IntegerTyping,
-            "rollbackonhealthcheckfailed" to BooleanTyping,
-            "justlogin" to BooleanTyping,
-            "docker_heroku_process_type" to EnumTyping("HerokuProcessType", listOf("web", "worker")),
-        )
-    ),
-
-    WrapperRequest(
-        ActionCoords("actions", "setup-python", "v2"),
-        mapOf(
-            "cache" to EnumTyping("PackageManager", listOf("pip", "pipenv")),
-            "architecture" to EnumTyping("Architecture", listOf("x64", "x86")),
-            "cache-dependency-path" to ListOfStringsTyping(" "),
-        )
-    ),
+    // Please keep the wrapper requests sorted ("actions/checkout" before "gradle/build-action")
+    // in order to minimize merge conflicts
 )


### PR DESCRIPTION
I had a look at my actions from https://github.com/jmfayard/refreshVersions
and this one is the only one I needed that was not present

I also sorted the wrapper requests.

If we don't do that, every one commits to the last element of the list, so we have a merge conflicts each time