### PR TITLE
generation: deprecated properties + invalid properties

### DIFF
--- a/library/src/gen/kotlin/it/krzeminski/githubactions/actions/actions/SetupNodeV2.kt
+++ b/library/src/gen/kotlin/it/krzeminski/githubactions/actions/actions/SetupNodeV2.kt
@@ -1,10 +1,13 @@
 // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
+@file:Suppress("DEPRECATION")
+
 package it.krzeminski.githubactions.actions.actions
 
 import it.krzeminski.githubactions.actions.Action
 import kotlin.Boolean
+import kotlin.Deprecated
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
@@ -67,6 +70,7 @@ public class SetupNodeV2(
     /**
      * Deprecated. Use node-version instead. Will not be supported after October 1, 2019
      */
+    @Deprecated("Deprecated. Use node-version instead. Will not be supported after October 1, 2019")
     public val version: String? = null
 ) : Action("actions", "setup-node", "v2") {
     @Suppress("SpreadOperator")

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
@@ -7,9 +7,10 @@ fun main() {
     // To ensure there are no leftovers from previous generations.
     Paths.get("library/src/gen").toFile().deleteRecursively()
 
-    wrappersToGenerate.forEach { (actionCoords, inputTypings) ->
+    wrappersToGenerate.forEach { request ->
+        val actionCoords = request.coords
         println("Generating ${actionCoords.owner}/${actionCoords.name}@${actionCoords.version}...")
-        val (code, path) = actionCoords.generateWrapper(inputTypings)
+        val (code, path) = request.generateWrapper()
         with(Paths.get(path).toFile()) {
             parentFile.mkdirs()
             writeText(code)

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
@@ -47,12 +47,13 @@ val wrappersToGenerate = listOf(
     ),
     WrapperRequest(
         ActionCoords("actions", "setup-node", "v2"),
-        mapOf(
+        inputTypings = mapOf(
             "always-auth" to BooleanTyping,
             "check-latest" to BooleanTyping,
             "cache" to EnumTyping("PackageManager", listOf("npm", "yarn", "pnpm")),
             "cache-dependency-path" to ListOfStringsTyping("\\n"),
         ),
+        deprecated = setOf("version"),
     ),
     WrapperRequest(
         ActionCoords("actions", "setup-python", "v2"),

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/domain/WrapperRequest.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/domain/WrapperRequest.kt
@@ -3,6 +3,7 @@ package it.krzeminski.githubactions.wrappergenerator.domain
 import it.krzeminski.githubactions.wrappergenerator.domain.typings.Typing
 
 data class WrapperRequest(
-    val actionCoords: ActionCoords,
+    val coords: ActionCoords,
     val inputTypings: Map<String, Typing> = emptyMap(),
+    val deprecated: Set<String> = emptySet(),
 )

--- a/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/wrappersfromunittests/SimpleActionWithRequiredStringInputsV3.kt
+++ b/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/wrappersfromunittests/SimpleActionWithRequiredStringInputsV3.kt
@@ -1,9 +1,12 @@
 // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
+@file:Suppress("DEPRECATION")
+
 package it.krzeminski.githubactions.actions.johnsmith
 
 import it.krzeminski.githubactions.actions.Action
+import kotlin.Deprecated
 import kotlin.String
 import kotlin.Suppress
 
@@ -20,8 +23,9 @@ public class SimpleActionWithRequiredStringInputsV3(
      */
     public val fooBar: String,
     /**
-     * Just another input
+     * Deprecated: Just another input
      */
+    @Deprecated("Deprecated: Just another input")
     public val bazGoo: String
 ) : Action("john-smith", "simple-action-with-required-string-inputs", "v3") {
     @Suppress("SpreadOperator")


### PR DESCRIPTION
actions/setup-node has a deprecated property, so I thought we can support that as well
I lost time with a typo of the property when I wrote a WrapperRequest so I added an early detection of those errors