### PR TITLE
Remove dependency on MockK

### DIFF
--- a/wrapper-generator/build.gradle.kts
+++ b/wrapper-generator/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
 
     testImplementation("io.kotest:kotest-assertions-core:5.1.0")
     testImplementation("io.kotest:kotest-runner-junit5:5.1.0")
-    testImplementation("io.mockk:mockk:1.12.2")
     testImplementation(project(":library"))
 }
 


### PR DESCRIPTION
After recent simplification in the tests, the mocking framework turns out to be
not needed.