### PR TITLE
Add PullRequest.types

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequest.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequest.kt
@@ -5,6 +5,7 @@ data class PullRequest(
     val branchesIgnore: List<String>? = null,
     val paths: List<String>? = null,
     val pathsIgnore: List<String>? = null,
+    val types: List<Type> = emptyList(),
 ) : Trigger() {
     init {
         require(!(branches != null && branchesIgnore != null)) {
@@ -13,5 +14,28 @@ data class PullRequest(
         require(!(paths != null && pathsIgnore != null)) {
             "Cannot define both 'paths' and 'pathsIgnore'!"
         }
+    }
+
+    /**
+     * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+     */
+    enum class Type {
+        Assigned,
+        Unassigned,
+        Labeled,
+        Unlabeled,
+        Opened,
+        Edited,
+        Closed,
+        Reopened,
+        Synchronize,
+        ConvertedToDraft,
+        ReadyForReview,
+        Locked,
+        Unlocked,
+        ReviewRequested,
+        ReviewRequestRemoved,
+        AutoMergeEnabled,
+        AutoMergeDisabled,
     }
 }

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequest.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequest.kt
@@ -1,11 +1,11 @@
 package it.krzeminski.githubactions.domain.triggers
 
 data class PullRequest(
+    val types: List<Type> = emptyList(),
     val branches: List<String>? = null,
     val branchesIgnore: List<String>? = null,
     val paths: List<String>? = null,
     val pathsIgnore: List<String>? = null,
-    val types: List<Type> = emptyList(),
 ) : Trigger() {
     init {
         require(!(branches != null && branchesIgnore != null)) {

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/Case.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/Case.kt
@@ -1,0 +1,8 @@
+package it.krzeminski.githubactions.yaml
+
+inline fun <reified T : Enum<T>> T.toSnakeCase(): String {
+    require(name.first() !in 'a'..'z' && name.all { it in 'a'..'z' || it in 'A'..'Z' })
+    return pascalCaseRegex.findAll(name).joinToString(separator = "_") { it.value.lowercase() }
+}
+
+val pascalCaseRegex = Regex("[A-Z][a-z]*")

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/TriggersToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/TriggersToYaml.kt
@@ -4,23 +4,6 @@ package it.krzeminski.githubactions.yaml
 
 import it.krzeminski.githubactions.domain.triggers.PullRequest
 import it.krzeminski.githubactions.domain.triggers.PullRequestTarget
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Assigned
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.AutoMergeDisabled
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.AutoMergeEnabled
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Closed
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.ConvertedToDraft
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Edited
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Labeled
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Locked
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Opened
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.ReadyForReview
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Reopened
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.ReviewRequestRemoved
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.ReviewRequested
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Synchronize
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Unassigned
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Unlabeled
-import it.krzeminski.githubactions.domain.triggers.PullRequestTarget.Type.Unlocked
 import it.krzeminski.githubactions.domain.triggers.Push
 import it.krzeminski.githubactions.domain.triggers.Schedule
 import it.krzeminski.githubactions.domain.triggers.Trigger
@@ -53,6 +36,7 @@ private fun Push.toYaml() = buildString {
 
 private fun PullRequest.toYaml() = buildString {
     appendLine("pull_request:")
+    printIfHasElements(this@toYaml.types.map(PullRequest.Type::toYaml), "types")
     printIfHasElements(this@toYaml.branches, "branches")
     printIfHasElements(this@toYaml.branchesIgnore, "branches-ignore")
     printIfHasElements(this@toYaml.paths, "paths")
@@ -68,26 +52,9 @@ private fun PullRequestTarget.toYaml() = buildString {
     printIfHasElements(this@toYaml.pathsIgnore, "paths-ignore")
 }.removeSuffix("\n")
 
-@Suppress("ComplexMethod")
-private fun PullRequestTarget.Type.toYaml(): String = when (this) {
-    Assigned -> "assigned"
-    Unassigned -> "unassigned"
-    Labeled -> "labeled"
-    Unlabeled -> "unlabeled"
-    Opened -> "opened"
-    Edited -> "edited"
-    Closed -> "closed"
-    Reopened -> "reopened"
-    Synchronize -> "synchronize"
-    ConvertedToDraft -> "converted_to_draft"
-    ReadyForReview -> "ready_for_review"
-    Locked -> "locked"
-    Unlocked -> "unlocked"
-    ReviewRequested -> "review_requested"
-    ReviewRequestRemoved -> "review_request_removed"
-    AutoMergeEnabled -> "auto_merge_enabled"
-    AutoMergeDisabled -> "auto_merge_disabled"
-}
+private fun PullRequestTarget.Type.toYaml(): String = this.toSnakeCase()
+
+private fun PullRequest.Type.toYaml(): String = this.toSnakeCase()
 
 private fun Schedule.toYaml() = buildString {
     appendLine("schedule:")

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/CaseTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/CaseTest.kt
@@ -1,0 +1,40 @@
+package it.krzeminski.githubactions.yaml
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+import it.krzeminski.githubactions.domain.triggers.PullRequest
+import it.krzeminski.githubactions.domain.triggers.PullRequest.Type
+import it.krzeminski.githubactions.domain.triggers.PullRequestTarget
+
+class CaseTest : DescribeSpec({
+    it("transforms to pascal case") {
+        listOf(
+            Type.Assigned to "assigned",
+            Type.AutoMergeDisabled to "auto_merge_disabled",
+            Type.ReviewRequested to "review_requested",
+        ).forAll { (type, expected) ->
+            type.toSnakeCase() shouldBe expected
+        }
+    }
+
+    it("should fail early if the enum is not in pascal case") {
+        MyEnum.values().forAll { enum ->
+            shouldThrowAny {
+                enum.toSnakeCase()
+            }
+        }
+    }
+
+    it("all enums should be in pascal case") {
+        PullRequestTarget.Type.values().forAll { it.toSnakeCase() }
+        PullRequest.Type.values().forAll { it.toSnakeCase() }
+    }
+})
+
+private enum class MyEnum {
+    invalid,
+    `in-valid`,
+    in_valid,
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/TriggersToYamlTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/TriggersToYamlTest.kt
@@ -196,6 +196,7 @@ class TriggersToYamlTest : DescribeSpec({
                 PullRequest(
                     branches = listOf("branch1", "branch2"),
                     paths = listOf("path1", "path2"),
+                    types = listOf(PullRequest.Type.AutoMergeDisabled, PullRequest.Type.Opened),
                 )
             )
 
@@ -205,6 +206,9 @@ class TriggersToYamlTest : DescribeSpec({
             // then
             yaml shouldBe """
                 |pull_request:
+                |  types:
+                |    - 'auto_merge_disabled'
+                |    - 'opened'
                 |  branches:
                 |    - 'branch1'
                 |    - 'branch2'


### PR DESCRIPTION
I am missing `PullRequest.types`

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

Interestingly enough it is identical to  `PullRequestTarget.types` which is already part of the library

I added `Enum.toSnakeCase()` because I think that doing an exhaustive when is more likely to bring us a typo error.