### PR TITLE
[#99] Allow setting arbitrary workflow/job/step attribute

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/actions/Action.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/actions/Action.kt
@@ -1,10 +1,14 @@
 package it.krzeminski.githubactions.actions
 
+import it.krzeminski.githubactions.dsl.FreeYamlArgs
+import it.krzeminski.githubactions.dsl.HasFreeYamlArgs
+
 abstract class Action(
     open val actionOwner: String,
     open val actionName: String,
     open val actionVersion: String,
-) {
+) : HasFreeYamlArgs {
+    override val freeYamlArgs: FreeYamlArgs = mutableListOf()
     abstract fun toYamlArguments(): LinkedHashMap<String, String>
 }
 

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Job.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Job.kt
@@ -1,5 +1,8 @@
 package it.krzeminski.githubactions.domain
 
+import it.krzeminski.githubactions.dsl.FreeYamlArgs
+import it.krzeminski.githubactions.dsl.HasFreeYamlArgs
+
 data class Job(
     val name: String,
     val runsOn: RunnerType,
@@ -8,4 +11,6 @@ data class Job(
     val env: LinkedHashMap<String, String> = linkedMapOf(),
     val condition: String? = null,
     val strategyMatrix: Map<String, List<String>>? = null,
-)
+) : HasFreeYamlArgs {
+    override val freeYamlArgs: FreeYamlArgs = mutableListOf()
+}

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
@@ -1,6 +1,8 @@
 package it.krzeminski.githubactions.domain
 
 import it.krzeminski.githubactions.domain.triggers.Trigger
+import it.krzeminski.githubactions.dsl.FreeYamlArgs
+import it.krzeminski.githubactions.dsl.HasFreeYamlArgs
 import java.nio.file.Path
 
 data class Workflow(
@@ -10,4 +12,6 @@ data class Workflow(
     val sourceFile: Path,
     val targetFile: Path,
     val jobs: List<Job>,
-)
+) : HasFreeYamlArgs {
+    override val freeYamlArgs: FreeYamlArgs = mutableListOf()
+}

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequest.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/PullRequest.kt
@@ -1,5 +1,7 @@
 package it.krzeminski.githubactions.domain.triggers
 
+import it.krzeminski.githubactions.dsl.FreeYamlArgs
+
 data class PullRequest(
     val types: List<Type> = emptyList(),
     val branches: List<String>? = null,
@@ -7,6 +9,7 @@ data class PullRequest(
     val paths: List<String>? = null,
     val pathsIgnore: List<String>? = null,
 ) : Trigger() {
+    override val freeYamlArgs: FreeYamlArgs = mutableListOf()
     init {
         require(!(branches != null && branchesIgnore != null)) {
             "Cannot define both 'branches' and 'branchesIgnore'!"

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/Trigger.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/triggers/Trigger.kt
@@ -1,3 +1,8 @@
 package it.krzeminski.githubactions.domain.triggers
 
-sealed class Trigger
+import it.krzeminski.githubactions.dsl.FreeYamlArgs
+import it.krzeminski.githubactions.dsl.HasFreeYamlArgs
+
+sealed class Trigger : HasFreeYamlArgs {
+    override val freeYamlArgs: FreeYamlArgs = mutableListOf()
+}

--- a/library/src/main/kotlin/it/krzeminski/githubactions/dsl/HasFreeYamlArgs.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/dsl/HasFreeYamlArgs.kt
@@ -1,0 +1,26 @@
+package it.krzeminski.githubactions.dsl
+
+interface HasFreeYamlArgs {
+    val freeYamlArgs: FreeYamlArgs
+}
+
+typealias FreeYamlArgs = MutableList<FreeArg>
+
+sealed class FreeArg
+data class StringFreeArg(val key: String, val value: String) : FreeArg()
+data class ListFreeArg(val key: String, val value: List<String>) : FreeArg()
+
+fun <T : HasFreeYamlArgs> T.withFreeArgs(vararg pairs: Pair<String, Any>): T = apply {
+    val map = pairs.mapNotNull { (key, value) ->
+        when {
+            value is String -> StringFreeArg(key, value)
+            value is Boolean -> StringFreeArg(key, value.toString())
+            value is Int -> StringFreeArg(key, value.toString())
+            value is List<*> -> ListFreeArg(key, value.map { it.toString() })
+            else -> null
+        }
+    }
+    require(map.size == pairs.size) { "Invalid free args: must be String or List\nGot ${pairs.toList()}" }
+    freeYamlArgs.clear()
+    freeYamlArgs.addAll(map)
+}

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
@@ -58,6 +58,7 @@ private fun Job.toYaml() = buildString {
 
     appendLine("  steps:")
     append(steps.stepsToYaml().prependIndent("    "))
+    append(freeArgsToYaml())
 }
 
 fun requireMatchesRegex(field: String, value: String, regex: Regex, url: String?) {

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -50,6 +50,11 @@ fun Workflow.toYaml(addConsistencyCheck: Boolean = true): String {
 
         appendLine("jobs:")
         append(jobsWithConsistencyCheck.jobsToYaml().prependIndent("  "))
+        freeArgsToYaml().takeIf { it.isNotBlank() }
+            ?.let { freeargs ->
+                append("\n")
+                append(freeargs.replaceIndent(""))
+            }
     }
 }
 

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/TriggersToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/TriggersToYaml.kt
@@ -9,6 +9,9 @@ import it.krzeminski.githubactions.domain.triggers.Schedule
 import it.krzeminski.githubactions.domain.triggers.Trigger
 import it.krzeminski.githubactions.domain.triggers.WorkflowDispatch
 import it.krzeminski.githubactions.domain.triggers.WorkflowDispatch.Type
+import it.krzeminski.githubactions.dsl.HasFreeYamlArgs
+import it.krzeminski.githubactions.dsl.ListFreeArg
+import it.krzeminski.githubactions.dsl.StringFreeArg
 
 fun List<Trigger>.triggersToYaml(): String =
     this
@@ -22,7 +25,17 @@ private fun Trigger.toYamlString() =
         is PullRequest -> toYaml()
         is PullRequestTarget -> toYaml()
         is Schedule -> toYaml()
+    } + freeArgsToYaml()
+
+internal fun HasFreeYamlArgs.freeArgsToYaml(): String = buildString {
+    append("\n")
+    for (arg in freeYamlArgs) {
+        when (arg) {
+            is ListFreeArg -> printIfHasElements(arg.value, arg.key)
+            is StringFreeArg -> appendLine("  ${arg.key}: ${arg.value}")
+        }
     }
+}.removeSuffix("\n")
 
 private fun Push.toYaml() = buildString {
     appendLine("push:")
@@ -90,7 +103,7 @@ private fun Type.toYaml(): String = when (this) {
     Type.String -> "string"
 }
 
-private fun StringBuilder.printIfHasElements(
+internal fun StringBuilder.printIfHasElements(
     items: List<String>?,
     name: String,
     space: String = "  ",

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/FreeYamlArgsTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/FreeYamlArgsTest.kt
@@ -1,0 +1,157 @@
+package it.krzeminski.githubactions.yaml
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import it.krzeminski.githubactions.actions.actions.CheckoutV2
+import it.krzeminski.githubactions.domain.ExternalActionStep
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Cron
+import it.krzeminski.githubactions.domain.triggers.PullRequest
+import it.krzeminski.githubactions.domain.triggers.PullRequestTarget
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.domain.triggers.Schedule
+import it.krzeminski.githubactions.domain.triggers.Trigger
+import it.krzeminski.githubactions.domain.triggers.WorkflowDispatch
+import it.krzeminski.githubactions.dsl.withFreeArgs
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+class FreeYamlArgsTest : FunSpec({
+    test("Action with free arguments") {
+        val action = CheckoutV2(
+            repository = "repository",
+            ref = "main",
+        ).withFreeArgs(
+            "hello" to "world",
+            "repository" to "jcenter",
+            "groceries" to listOf("cheese", "wine"),
+        )
+
+        val step = ExternalActionStep(
+            id = "someId",
+            name = "Some external action",
+            action = action,
+        )
+        listOf(step).stepsToYaml() shouldBe """
+            - id: someId
+              name: Some external action
+              uses: actions/checkout@v2
+              with:
+                repository: jcenter
+                ref: main
+                hello: world
+                groceries:
+                  - 'cheese'
+                  - 'wine'
+        """.trimIndent()
+    }
+
+    test("Triggers with free yaml args") {
+        val triggers: List<Trigger> = listOf(
+            PullRequest().withFreeArgs(
+                "types" to listOf("ignored"),
+                "lang" to "french",
+                "list" to listOf(1, 2, 3)
+            ),
+            WorkflowDispatch().withFreeArgs(
+                "lang" to "french",
+                "list" to listOf(1, 2, 3)
+            ),
+            Push().withFreeArgs(
+                "branches" to listOf("main", "master"),
+                "tags" to listOf("tag1", "tag2")
+            ),
+            Schedule(emptyList()).withFreeArgs(
+                "cron" to Cron(hour = "7", minute = "0").expression
+            ),
+            PullRequestTarget().withFreeArgs(
+                "branches" to listOf("main", "master"),
+                "tags" to listOf("tag1", "tag2")
+            ),
+        )
+        triggers.triggersToYaml() shouldBe """
+            pull_request:
+              types:
+                - 'ignored'
+              lang: french
+              list:
+                - '1'
+                - '2'
+                - '3'
+            workflow_dispatch:
+              lang: french
+              list:
+                - '1'
+                - '2'
+                - '3'
+            push:
+              branches:
+                - 'main'
+                - 'master'
+              tags:
+                - 'tag1'
+                - 'tag2'
+            schedule:
+              cron: 0 7 * * *
+            pull_request_target:
+              branches:
+                - 'main'
+                - 'master'
+              tags:
+                - 'tag1'
+                - 'tag2'
+        """.trimIndent()
+    }
+
+    test("Workflow and Job with free yaml args") {
+        val workflow = workflow(
+            name = "Test workflow",
+            on = listOf(Push()),
+            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+        ) {
+            job(
+                name = "test_job",
+                runsOn = RunnerType.UbuntuLatest,
+            ) {
+                run(
+                    name = "Hello world!",
+                    command = "echo 'hello!'",
+                )
+            }.withFreeArgs(
+                "distribute-job" to true,
+                "servers" to listOf("server-1", "server-2")
+            )
+        }
+        workflow.withFreeArgs(
+            "dry-run" to true,
+            "written-by" to listOf("Alice", "Bob")
+        )
+        workflow.toYaml(addConsistencyCheck = false) shouldBe """
+          # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+          # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+          # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+          
+          name: Test workflow
+          
+          on:
+            push:
+          
+          jobs:
+            "test_job":
+              runs-on: "ubuntu-latest"
+              steps:
+                - id: step-0
+                  name: Hello world!
+                  run: echo 'hello!'
+              distribute-job: true
+              servers:
+                - 'server-1'
+                - 'server-2'
+          dry-run: true
+          written-by:
+            - 'Alice'
+            - 'Bob'
+        """.trimIndent()
+    }
+})


### PR DESCRIPTION
 Allow setting arbitrary workflow/job/step attribute via `withFreeArgs(...)`
https://github.com/krzema12/github-actions-kotlin-dsl/issues/99

```kotlin
val action = CheckoutV2(
    repository = "repository",
    ref = "main",
).withFreeArgs(
    "hello" to "world",
    "repository" to "jcenter",
    "groceries" to listOf("cheese", "wine"),
)
val trigger = PullRequest().withFreeArgs(
    "types" to listOf("ignored"),
    "lang" to "french",
    "list" to listOf(1, 2, 3)
)

val workflow = workflow(
) {
    job(
        name = "test_job",
        runsOn = RunnerType.UbuntuLatest,
    ) {
    }.withFreeArgs(
        "distribute-job" to true,
        "servers" to listOf("server-1", "server-2")
    )
}.withFreeArgs(
    "dry-run" to true,
    "written-by" to listOf("Alice", "Bob")
)
```