### PR TITLE
Run Gradle wrapper validation only if wrapper changes

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.main.kts
+++ b/.github/workflows/gradle-wrapper-validation.main.kts
@@ -11,8 +11,13 @@ import java.nio.file.Paths
 val gradleWrapperValidationWorkflow = workflow(
     name = "Validate Gradle wrapper",
     on = listOf(
-        Push(branches = listOf("main")),
-        PullRequest(),
+        Push(
+            branches = listOf("main"),
+            paths = listOf("gradle/wrapper/gradle-wrapper.jar"),
+        ),
+        PullRequest(
+            paths = listOf("gradle/wrapper/gradle-wrapper.jar"),
+        ),
     ),
     sourceFile = Paths.get(".github/workflows/_GenerateWorkflows.main.kts"),
     targetFile = Paths.get(".github/workflows/gradle-wrapper-validation.yaml"),

--- a/.github/workflows/gradle-wrapper-validation.yaml
+++ b/.github/workflows/gradle-wrapper-validation.yaml
@@ -8,7 +8,11 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - 'gradle/wrapper/gradle-wrapper.jar'
   pull_request:
+    paths:
+      - 'gradle/wrapper/gradle-wrapper.jar'
 
 jobs:
   "check_yaml_consistency":


### PR DESCRIPTION
In practice it happens very rarely, so this optimization will reduce
processing power consumption and clutter in PR workflow reports.