### PR TITLE
tests: compare GeneratedFile.kt with GeneratedFileActual.kt

### DIFF
--- a/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/GenerationTest.kt
+++ b/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/GenerationTest.kt
@@ -2,7 +2,6 @@ package it.krzeminski.githubactions.wrappergenerator.generation
 
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
 import it.krzeminski.githubactions.wrappergenerator.domain.ActionCoords
 import it.krzeminski.githubactions.wrappergenerator.domain.typings.BooleanTyping
@@ -39,53 +38,9 @@ class GenerationTest : FunSpec({
 
         // when
         val wrapper = coords.generateWrapper { actionManifest }
-        writeToUnitTests(wrapper)
 
         // then
-        wrapper shouldBe Wrapper(
-            kotlinCode = """
-                // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
-                // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
-                // generator itself.
-                @file:Suppress("DEPRECATION")
-                
-                package it.krzeminski.githubactions.actions.johnsmith
-
-                import it.krzeminski.githubactions.actions.Action
-                import kotlin.Deprecated
-                import kotlin.String
-                import kotlin.Suppress
-
-                /**
-                 * Action: Do something cool
-                 *
-                 * This is a test description that should be put in the KDoc comment for a class
-                 *
-                 * [Action on GitHub](https://github.com/john-smith/simple-action-with-required-string-inputs)
-                 */
-                public class SimpleActionWithRequiredStringInputsV3(
-                    /**
-                     * Short description
-                     */
-                    public val fooBar: String,
-                    /**
-                     * Just another input
-                     */
-                    @Deprecated("this is deprecated")
-                    public val bazGoo: String
-                ) : Action("john-smith", "simple-action-with-required-string-inputs", "v3") {
-                    @Suppress("SpreadOperator")
-                    public override fun toYamlArguments() = linkedMapOf(
-                        *listOfNotNull(
-                            "foo-bar" to fooBar,
-                            "baz-goo" to bazGoo,
-                        ).toTypedArray()
-                    )
-                }
-
-            """.trimIndent(),
-            filePath = "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/SimpleActionWithRequiredStringInputsV3.kt",
-        )
+        wrapper.shouldMatchFile("SimpleActionWithRequiredStringInputsV3.kt")
     }
 
     test("action with various combinations of input parameters describing being required or optional") {
@@ -121,64 +76,9 @@ class GenerationTest : FunSpec({
 
         // when
         val wrapper = coords.generateWrapper(fetchMetadataImpl = { actionManifest })
-        writeToUnitTests(wrapper)
 
         // then
-        wrapper shouldBe Wrapper(
-            kotlinCode = """
-                // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
-                // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
-                // generator itself.
-                package it.krzeminski.githubactions.actions.johnsmith
-
-                import it.krzeminski.githubactions.actions.Action
-                import kotlin.String
-                import kotlin.Suppress
-
-                /**
-                 * Action: Do something cool
-                 *
-                 * This is a test description that should be put in the KDoc comment for a class
-                 *
-                 * [Action on GitHub](https://github.com/john-smith/action-with-some-optional-inputs)
-                 */
-                public class ActionWithSomeOptionalInputsV3(
-                    /**
-                     * Required is default, default is set
-                     */
-                    public val fooBar: String? = null,
-                    /**
-                     * Required is default, default is null
-                     */
-                    public val bazGoo: String? = null,
-                    /**
-                     * Required is false, default is set
-                     */
-                    public val zooDar: String? = null,
-                    /**
-                     * Required is false, default is default
-                     */
-                    public val cooPoo: String? = null,
-                    /**
-                     * Required is true, default is default
-                     */
-                    public val `package`: String
-                ) : Action("john-smith", "action-with-some-optional-inputs", "v3") {
-                    @Suppress("SpreadOperator")
-                    public override fun toYamlArguments() = linkedMapOf(
-                        *listOfNotNull(
-                            fooBar?.let { "foo-bar" to it },
-                            bazGoo?.let { "baz-goo" to it },
-                            zooDar?.let { "zoo-dar" to it },
-                            cooPoo?.let { "coo-poo" to it },
-                            "package" to `package`,
-                        ).toTypedArray()
-                    )
-                }
-
-            """.trimIndent(),
-            filePath = "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/ActionWithSomeOptionalInputsV3.kt",
-        )
+        wrapper.shouldMatchFile("ActionWithSomeOptionalInputsV3.kt")
     }
 
     test("action with non-string inputs") {
@@ -244,118 +144,9 @@ class GenerationTest : FunSpec({
                 "bah-enum" to EnumTyping("Bah", listOf("helloworld"), listOf("HelloWorld")),
             ),
         )
-        writeToUnitTests(wrapper)
 
         // then
-        wrapper shouldBe Wrapper(
-            kotlinCode = """
-                // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
-                // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
-                // generator itself.
-                package it.krzeminski.githubactions.actions.johnsmith
-
-                import it.krzeminski.githubactions.actions.Action
-                import kotlin.Boolean
-                import kotlin.Int
-                import kotlin.String
-                import kotlin.Suppress
-                import kotlin.collections.List
-
-                /**
-                 * Action: Do something cool
-                 *
-                 * This is a test description that should be put in the KDoc comment for a class
-                 *
-                 * [Action on GitHub](https://github.com/john-smith/action-with-non-string-inputs)
-                 */
-                public class ActionWithNonStringInputsV3(
-                    /**
-                     * Short description
-                     */
-                    public val fooBar: String,
-                    /**
-                     * First boolean input!
-                     */
-                    public val bazGoo: Boolean,
-                    /**
-                     * Boolean and nullable
-                     */
-                    public val binKin: Boolean? = null,
-                    /**
-                     * Integer
-                     */
-                    public val intPint: Int,
-                    /**
-                     * List of strings
-                     */
-                    public val booZoo: List<String>,
-                    /**
-                     * Enumeration
-                     */
-                    public val finBin: ActionWithNonStringInputsV3.Bin,
-                    /**
-                     * Integer with special value
-                     */
-                    public val gooZen: ActionWithNonStringInputsV3.Zen,
-                    /**
-                     * Enum with custom naming
-                     */
-                    public val bahEnum: ActionWithNonStringInputsV3.Bah
-                ) : Action("john-smith", "action-with-non-string-inputs", "v3") {
-                    @Suppress("SpreadOperator")
-                    public override fun toYamlArguments() = linkedMapOf(
-                        *listOfNotNull(
-                            "foo-bar" to fooBar,
-                            "baz-goo" to bazGoo.toString(),
-                            binKin?.let { "bin-kin" to it.toString() },
-                            "int-pint" to intPint.toString(),
-                            "boo-zoo" to booZoo.joinToString(","),
-                            "fin-bin" to finBin.stringValue,
-                            "goo-zen" to gooZen.integerValue.toString(),
-                            "bah-enum" to bahEnum.stringValue,
-                        ).toTypedArray()
-                    )
-
-                    public sealed class Bin(
-                        public val stringValue: String
-                    ) {
-                        public object Foo : ActionWithNonStringInputsV3.Bin("foo")
-
-                        public object BooBar : ActionWithNonStringInputsV3.Bin("boo-bar")
-
-                        public object Baz123 : ActionWithNonStringInputsV3.Bin("baz123")
-
-                        public class Custom(
-                            customStringValue: String
-                        ) : ActionWithNonStringInputsV3.Bin(customStringValue)
-                    }
-
-                    public sealed class Zen(
-                        public val integerValue: Int
-                    ) {
-                        public class Value(
-                            requestedValue: Int
-                        ) : ActionWithNonStringInputsV3.Zen(requestedValue)
-
-                        public object Special1 : ActionWithNonStringInputsV3.Zen(3)
-
-                        public object Special2 : ActionWithNonStringInputsV3.Zen(-1)
-                    }
-
-                    public sealed class Bah(
-                        public val stringValue: String
-                    ) {
-                        public object HelloWorld : ActionWithNonStringInputsV3.Bah("helloworld")
-
-                        public class Custom(
-                            customStringValue: String
-                        ) : ActionWithNonStringInputsV3.Bah(customStringValue)
-                    }
-                }
-
-            """.trimIndent(),
-            filePath = "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/ActionWithNonStringInputsV3.kt",
-        )
+        wrapper.shouldMatchFile("ActionWithNonStringInputsV3.kt")
     }
 
     test("action with outputs") {
@@ -379,62 +170,9 @@ class GenerationTest : FunSpec({
 
         // when
         val wrapper = coords.generateWrapper { actionManifest }
-        writeToUnitTests(wrapper)
 
         // then
-        wrapper shouldBe Wrapper(
-            kotlinCode = """
-                // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
-                // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
-                // generator itself.
-                package it.krzeminski.githubactions.actions.johnsmith
-
-                import it.krzeminski.githubactions.actions.ActionWithOutputs
-                import kotlin.String
-                import kotlin.Suppress
-
-                /**
-                 * Action: Do something cool
-                 *
-                 * This is a test description that should be put in the KDoc comment for a class
-                 *
-                 * [Action on GitHub](https://github.com/john-smith/action-with-outputs)
-                 */
-                public class ActionWithOutputsV3(
-                    /**
-                     * Short description
-                     */
-                    public val fooBar: String
-                ) : ActionWithOutputs<ActionWithOutputsV3.Outputs>("john-smith", "action-with-outputs", "v3") {
-                    @Suppress("SpreadOperator")
-                    public override fun toYamlArguments() = linkedMapOf(
-                        *listOfNotNull(
-                            "foo-bar" to fooBar,
-                        ).toTypedArray()
-                    )
-
-                    public override fun buildOutputObject(stepId: String) = Outputs(stepId)
-
-                    public class Outputs(
-                        private val stepId: String
-                    ) {
-                        /**
-                         * Cool output!
-                         */
-                        public val bazGoo: String = "steps.${'$'}stepId.outputs.baz-goo"
-
-                        /**
-                         * Another output...
-                         */
-                        public val looWoz: String = "steps.${'$'}stepId.outputs.loo-woz"
-
-                        public operator fun `get`(outputName: String) = "steps.${'$'}stepId.outputs.${'$'}outputName"
-                    }
-                }
-
-            """.trimIndent(),
-            filePath = "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/ActionWithOutputsV3.kt",
-        )
+        wrapper.shouldMatchFile("ActionWithOutputsV3.kt")
     }
 
     test("Detect wrapper request with invalid properties") {
@@ -481,35 +219,9 @@ class GenerationTest : FunSpec({
 
         // when
         val wrapper = coords.generateWrapper { actionManifest }
-        writeToUnitTests(wrapper)
 
         // then
-        wrapper shouldBe Wrapper(
-            kotlinCode = """
-                // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
-                // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
-                // generator itself.
-                package it.krzeminski.githubactions.actions.johnsmith
-
-                import it.krzeminski.githubactions.actions.Action
-                import java.util.LinkedHashMap
-                import kotlin.Suppress
-
-                /**
-                 * Action: Action With No Inputs
-                 *
-                 * Description
-                 *
-                 * [Action on GitHub](https://github.com/john-smith/action-with-no-inputs)
-                 */
-                public class ActionWithNoInputsV3() : Action("john-smith", "action-with-no-inputs", "v3") {
-                    @Suppress("SpreadOperator")
-                    public override fun toYamlArguments() = LinkedHashMap<String, String>()
-                }
-                
-            """.trimIndent(),
-            filePath = "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/ActionWithNoInputsV3.kt",
-        )
+        wrapper.shouldMatchFile("ActionWithNoInputsV3.kt")
     }
 
     test("action v2 deprecated by v3") {
@@ -525,42 +237,9 @@ class GenerationTest : FunSpec({
 
         // when
         val wrapper = coords.generateWrapper { actionManifest }
-        writeToUnitTests(wrapper)
 
         // then
-        wrapper shouldBe Wrapper(
-            kotlinCode = """
-                // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
-                // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
-                // generator itself.
-                @file:Suppress("DEPRECATION")
-
-                package it.krzeminski.githubactions.actions.johnsmith
-
-                import it.krzeminski.githubactions.actions.Action
-                import java.util.LinkedHashMap
-                import kotlin.Deprecated
-                import kotlin.Suppress
-
-                /**
-                 * Action: Deprecated Action
-                 *
-                 * Description
-                 *
-                 * [Action on GitHub](https://github.com/john-smith/deprecated-action)
-                 */
-                @Deprecated(
-                    message = "This action has a newer major version: DeprecatedActionV3",
-                    replaceWith = ReplaceWith("DeprecatedActionV3")
-                )
-                public class DeprecatedActionV2() : Action("john-smith", "deprecated-action", "v2") {
-                    @Suppress("SpreadOperator")
-                    public override fun toYamlArguments() = LinkedHashMap<String, String>()
-                }
-
-            """.trimIndent(),
-            filePath = "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/DeprecatedActionV2.kt",
-        )
+        wrapper.shouldMatchFile("DeprecatedActionV2.kt")
     }
 
     test("action with ListOfTypings") {
@@ -591,85 +270,8 @@ class GenerationTest : FunSpec({
 
         // when
         val wrapper = coords.generateWrapper(inputTypings) { actionManifest }
-        writeToUnitTests(wrapper)
 
         // then
-        wrapper shouldBe Wrapper(
-            kotlinCode = """
-                // This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
-                // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
-                // generator itself.
-                package it.krzeminski.githubactions.actions.johnsmith
-
-                import it.krzeminski.githubactions.actions.Action
-                import kotlin.Int
-                import kotlin.String
-                import kotlin.Suppress
-                import kotlin.collections.List
-
-                /**
-                 * Action: Do something cool
-                 *
-                 * This is a test description that should be put in the KDoc comment for a class
-                 *
-                 * [Action on GitHub](https://github.com/john-smith/simple-action-with-lists)
-                 */
-                public class SimpleActionWithListsV3(
-                    /**
-                     * List of strings
-                     */
-                    public val listStrings: List<String>? = null,
-                    /**
-                     * List of integers
-                     */
-                    public val listInts: List<Int>? = null,
-                    /**
-                     * List of enums
-                     */
-                    public val listEnums: List<SimpleActionWithListsV3.MyEnum>? = null,
-                    /**
-                     * List of integer with special values
-                     */
-                    public val listIntSpecial: List<SimpleActionWithListsV3.MyInt>? = null
-                ) : Action("john-smith", "simple-action-with-lists", "v3") {
-                    @Suppress("SpreadOperator")
-                    public override fun toYamlArguments() = linkedMapOf(
-                        *listOfNotNull(
-                            listStrings?.let { "list-strings" to it.joinToString(",") },
-                            listInts?.let { "list-ints" to it.joinToString(",") { it.toString() } },
-                            listEnums?.let { "list-enums" to it.joinToString(",") { it.stringValue } },
-                            listIntSpecial?.let { "list-int-special" to it.joinToString(",") {
-                                    it.integerValue.toString() } },
-                        ).toTypedArray()
-                    )
-
-                    public sealed class MyEnum(
-                        public val stringValue: String
-                    ) {
-                        public object One : SimpleActionWithListsV3.MyEnum("one")
-
-                        public object Two : SimpleActionWithListsV3.MyEnum("two")
-
-                        public object Three : SimpleActionWithListsV3.MyEnum("three")
-
-                        public class Custom(
-                            customStringValue: String
-                        ) : SimpleActionWithListsV3.MyEnum(customStringValue)
-                    }
-
-                    public sealed class MyInt(
-                        public val integerValue: Int
-                    ) {
-                        public class Value(
-                            requestedValue: Int
-                        ) : SimpleActionWithListsV3.MyInt(requestedValue)
-
-                        public object TheAnswer : SimpleActionWithListsV3.MyInt(42)
-                    }
-                }
-
-            """.trimIndent(),
-            filePath = "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/SimpleActionWithListsV3.kt",
-        )
+        wrapper.shouldMatchFile("SimpleActionWithListsV3.kt")
     }
 })

--- a/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/Utils.kt
+++ b/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/Utils.kt
@@ -1,8 +1,29 @@
 package it.krzeminski.githubactions.wrappergenerator.generation
 
+import io.kotest.assertions.fail
+import io.kotest.matchers.shouldBe
 import java.nio.file.Paths
 
-fun writeToUnitTests(wrapper: Wrapper) {
-    Paths.get("src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/wrappersfromunittests/${Paths.get(wrapper.filePath).fileName}")
-        .toFile().writeText(wrapper.kotlinCode)
+fun Wrapper.shouldMatchFile(path: String) {
+    val expectedFile =
+        Paths.get("src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/wrappersfromunittests/$path")
+            .toFile()
+    val actualFile = expectedFile.resolveSibling(expectedFile.nameWithoutExtension + "Actual.kt")
+    val expected = if (expectedFile.canRead()) expectedFile.readText() else ""
+
+    filePath shouldBe "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/$path"
+
+    if (System.getenv("GITHUB_ACTIONS") == "true") {
+        kotlinCode shouldBe expected
+    } else if (kotlinCode == expected) {
+        actualFile.delete()
+    } else {
+        actualFile.writeText(
+            kotlinCode.replace(
+                "package it.krzeminski.githubactions.actions.johnsmith",
+                "package it.krzeminski.githubactions.actions.actual"
+            )
+        )
+        fail("The Wrapper's kotlin code in ${actualFile.name} doesn't match ${expectedFile.name}\nSee folder ${expectedFile.parentFile.canonicalPath}")
+    }
 }

--- a/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/Utils.kt
+++ b/wrapper-generator/src/test/kotlin/it/krzeminski/githubactions/wrappergenerator/generation/Utils.kt
@@ -2,6 +2,8 @@ package it.krzeminski.githubactions.wrappergenerator.generation
 
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.contain
 import java.nio.file.Paths
 
 fun Wrapper.shouldMatchFile(path: String) {
@@ -17,16 +19,17 @@ fun Wrapper.shouldMatchFile(path: String) {
 
     filePath shouldBe "library/src/gen/kotlin/it/krzeminski/githubactions/actions/johnsmith/$path"
 
+    val packageName = "it.krzeminski.githubactions.actions.johnsmith"
+    expectedContent shouldNot contain("package $packageName.actual")
+
     if (System.getenv("GITHUB_ACTIONS") == "true") {
         actualContent shouldBe expectedContent
     } else if (actualContent == expectedContent) {
         actualFile.delete()
     } else {
         actualFile.writeText(
-            actualContent.replace(
-                "package it.krzeminski.githubactions.actions.johnsmith",
-                "package it.krzeminski.githubactions.actions.actual"
-            )
+            // change the package to avoid compilation errors because of duplicate classes / functions
+            actualContent.replace("package $packageName", "package $packageName.actual")
         )
         fail("The Wrapper's kotlin code in ${actualFile.name} doesn't match ${expectedFile.name}\nSee folder ${expectedFile.parentFile.canonicalPath}")
     }


### PR DESCRIPTION
When a generated file doesn't match what was expected,
the actual content is written to a file GeneratedFileActual.kt

Use IntelliJ's "Compare Files" Actions
and update GeneratedFile.kt if the change looks good

Next time the test run and match the expected content,
GeneratedFileActual.kt will be deleted

On GitHub Actions, fail instead of creating a new file