### PR TITLE
Add a cache for action.yml files

### DIFF
--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/GenerationEntryPoint.kt
@@ -6,6 +6,7 @@ import it.krzeminski.githubactions.wrappergenerator.generation.generateWrapper
 import it.krzeminski.githubactions.wrappergenerator.generation.suggestDeprecations
 import it.krzeminski.githubactions.wrappergenerator.generation.toKotlinPackageName
 import it.krzeminski.githubactions.wrappergenerator.metadata.actionYmlUrl
+import it.krzeminski.githubactions.wrappergenerator.metadata.deleteActionYamlCacheIfObsolete
 import it.krzeminski.githubactions.wrappergenerator.metadata.prettyPrint
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -33,6 +34,7 @@ fun main() {
 }
 
 private fun generateWrappers() {
+    deleteActionYamlCacheIfObsolete()
     wrappersToGenerate.forEach { (actionCoords, inputTypings) ->
         println("Generating ${actionCoords.prettyPrint}")
         val (code, path) = actionCoords.generateWrapper(inputTypings)

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/metadata/MetadataReading.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/metadata/MetadataReading.kt
@@ -4,8 +4,10 @@ import com.charleskorn.kaml.Yaml
 import it.krzeminski.githubactions.wrappergenerator.domain.ActionCoords
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
+import java.io.File
 import java.io.IOException
 import java.net.URI
+import java.time.LocalDate
 
 /**
  * [Metadata syntax for GitHub Actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions).
@@ -45,6 +47,11 @@ val ActionCoords.releasesUrl: String get() = "https://github.com/$owner/$name/re
 val ActionCoords.prettyPrint: String get() = """ActionCoords("$owner", "$name", "$version")"""
 
 fun ActionCoords.fetchMetadata(fetchUri: (URI) -> String = ::fetchUri): Metadata {
+    val cacheFile = actionYamlDir.resolve("$owner-$name-$version.yml")
+    if (cacheFile.canRead()) {
+        return myYaml.decodeFromString(cacheFile.readText())
+    }
+
     val list = listOf(actionYmlUrl, actionYamlUrl, actionYmlNoVUrl, actionYamlNoVUrl)
     val metadataYaml = list.firstNotNullOfOrNull { url ->
         try {
@@ -55,6 +62,7 @@ fun ActionCoords.fetchMetadata(fetchUri: (URI) -> String = ::fetchUri): Metadata
         }
     } ?: error("$prettyPrint\n†Can't fetch any of those URLs:\n- ${list.joinToString(separator = "\n- ")}\nCheck release page $releasesUrl")
 
+    cacheFile.writeText(metadataYaml)
     return myYaml.decodeFromString(metadataYaml)
 }
 
@@ -65,3 +73,17 @@ val myYaml = Yaml(
         strictMode = false,
     )
 )
+
+val actionYamlDir = File("build/action-yaml")
+
+fun deleteActionYamlCacheIfObsolete() {
+    val today = LocalDate.now().toString()
+    val dateTxt = actionYamlDir.resolve("date.txt")
+    val cacheUpToDate = dateTxt.canRead() && dateTxt.readText() == today
+
+    if (!cacheUpToDate) {
+        actionYamlDir.deleteRecursively()
+        actionYamlDir.mkdir()
+        dateTxt.writeText(today)
+    }
+}


### PR DESCRIPTION
We talked about downloading action.yaml files in parallel, but there is even better : adding a cache to avoid re-downloading the same files over and over again.

- Add a cache `build/actions-checkout-v2.yml` for `Action("actions", "checkout", "v2")`
- A file `build/date.txt` checks that the downloaded files are from same day

With this change, the Kotlinpoet task runs in 1.5 seconds.