### PR TITLE
[#191] fix(wrapper-generator): don't create an issue if no version su…

### DIFF
--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/versions/SuggestVersions.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/versions/SuggestVersions.kt
@@ -44,8 +44,13 @@ fun main() {
     }
     println(output)
     File("build/suggestVersions.md").let { file ->
-        println("Updated ${file.absolutePath}")
-        file.writeText(output)
+        if (output.isNotEmpty()) {
+            println("Updated ${file.absolutePath}")
+            file.writeText(output)
+        } else {
+            println("No versions to suggest - ensuring that ${file.absolutePath} doesn't exist")
+            file.delete()
+        }
     }
 }
 


### PR DESCRIPTION
…ggestions

It utilizes this part of the API of peter-evans/create-issue-from-file:

> This action will create an issue if a file exists at a specified
> path. The content of the issue will be taken from the file as-is. If
> the file does not exist the action exits silently.