### PR TITLE
mkdocs.yml - add light/dark mode toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,15 @@ theme:
   name: material
   features:
     - navigation.expand
+  palette: 
+    - scheme: default
+      toggle:
+        icon: material/toggle-switch-off-outline 
+        name: Switch to dark mode
+    - scheme: slate 
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
 
 markdown_extensions:
   - pymdownx.magiclink


### PR DESCRIPTION
This should add a light/dark mode toggle. It's just a quick suggestion. I haven't tested if it works!

Config copied from: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle