### PR TITLE
[#69] feat(library): Custom runner type from string

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/RunnerType.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/RunnerType.kt
@@ -4,22 +4,25 @@ package it.krzeminski.githubactions.domain
  * Types of GitHub-hosted runners available. Should be kept in sync with the official list at
  * https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
  */
-enum class RunnerType {
+sealed interface RunnerType {
+    // Custom runner. Could be an expression `runsOn = expr("github.event.inputs.run-on")`
+    data class Custom(val runsOn: String) : RunnerType
+
     // "Latest" labels
-    UbuntuLatest,
-    WindowsLatest,
-    MacOSLatest,
+    object UbuntuLatest : RunnerType
+    object WindowsLatest : RunnerType
+    object MacOSLatest : RunnerType
 
     // Windows runners
-    Windows2022,
-    Windows2019,
-    Windows2016,
+    object Windows2022 : RunnerType
+    object Windows2019 : RunnerType
+    object Windows2016 : RunnerType
 
     // Ubuntu runners
-    Ubuntu2004,
-    Ubuntu1804,
+    object Ubuntu2004 : RunnerType
+    object Ubuntu1804 : RunnerType
 
     // macOS runners
-    MacOS11,
-    MacOS1015,
+    object MacOS11 : RunnerType
+    object MacOS1015 : RunnerType
 }

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
@@ -2,6 +2,7 @@ package it.krzeminski.githubactions.yaml
 
 import it.krzeminski.githubactions.domain.Job
 import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.RunnerType.Custom
 import it.krzeminski.githubactions.domain.RunnerType.MacOS1015
 import it.krzeminski.githubactions.domain.RunnerType.MacOS11
 import it.krzeminski.githubactions.domain.RunnerType.MacOSLatest
@@ -70,6 +71,7 @@ private fun Job.toYaml() = buildString {
 
 fun RunnerType.toYaml() =
     when (this) {
+        is Custom -> runsOn
         UbuntuLatest -> "ubuntu-latest"
         WindowsLatest -> "windows-latest"
         MacOSLatest -> "macos-latest"

--- a/script-generator/build.gradle.kts
+++ b/script-generator/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     testImplementation("io.kotest:kotest-assertions-core:5.2.3")
     testImplementation("io.kotest:kotest-runner-junit5:5.2.3")
+    implementation(kotlin("reflect"))
 }
 
 tasks.withType<Test> {

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/Jobs.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/Jobs.kt
@@ -1,11 +1,11 @@
 package it.krzeminski.githubactions.scriptgenerator
 
 import com.squareup.kotlinpoet.CodeBlock
-import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.dsl.ListCustomValue
 import it.krzeminski.githubactions.scriptmodel.YamlJob
 import it.krzeminski.githubactions.scriptmodel.YamlStep
 import it.krzeminski.githubactions.scriptmodel.YamlWorkflow
+import it.krzeminski.githubactions.scriptmodel.runnerTypeBlockOf
 import it.krzeminski.githubactions.wrappergenerator.domain.WrapperRequest
 import it.krzeminski.githubactions.wrappergenerator.generation.buildActionClassName
 import it.krzeminski.githubactions.wrappergenerator.wrappersToGenerate
@@ -16,7 +16,7 @@ fun YamlWorkflow.generateJobs() = CodeBlock { builder ->
             .indent()
             .add("id = %S,\n", jobId)
         if (job.name != null) builder.add("name = %S,\n", job.name)
-        builder.add("runsOn = %M,\n", enumMemberName<RunnerType>(job.runsOn) ?: enumMemberName(RunnerType.UbuntuLatest))
+        builder.add(runnerTypeBlockOf(job.runsOn))
         builder.add(concurrencyOf(job.concurrency))
         builder.add(
             job.env.joinToCode(

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/KotlinPoet.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/KotlinPoet.kt
@@ -23,6 +23,12 @@ inline fun <reified T : Enum<T>> enumMemberName(input: String): MemberName? {
         }
 }
 
+inline fun <reified T> objectsOfSealedClass(): List<T> {
+    require(T::class.isSealed) { "Expected sealed class, got ${T::class}" }
+    return T::class.sealedSubclasses
+        .mapNotNull { it.objectInstance }
+}
+
 fun normalizeEnum(s: String): String =
     s.replace("[ _+-]".toRegex(), "").lowercase()
 

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptmodel/RunnerTypes.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptmodel/RunnerTypes.kt
@@ -1,0 +1,28 @@
+package it.krzeminski.githubactions.scriptmodel
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.asClassName
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.scriptgenerator.CodeBlock
+import it.krzeminski.githubactions.scriptgenerator.normalizeEnum
+import it.krzeminski.githubactions.scriptgenerator.objectsOfSealedClass
+import it.krzeminski.githubactions.scriptgenerator.orExpression
+import it.krzeminski.githubactions.yaml.toYaml
+
+val allRunnerTypes: List<RunnerType> by lazy {
+    objectsOfSealedClass()
+}
+
+fun runnerTypeBlockOf(runsOn: String): CodeBlock {
+    val runnerType = allRunnerTypes.firstOrNull { normalizeEnum(it.toYaml()) == normalizeEnum(runsOn) }
+        ?: RunnerType.UbuntuLatest.takeIf { runsOn.isBlank() }
+    return if (runnerType != null) {
+        CodeBlock.of("runsOn = %T,\n", runnerType::class.asClassName())
+    } else {
+        CodeBlock { builder ->
+            builder.add(CodeBlock.of("runsOn = %T(", RunnerType.Custom::class.asClassName()))
+                .add(runsOn.orExpression())
+                .add(CodeBlock.of("),\n"))
+        }
+    }
+}

--- a/script-generator/src/test/kotlin/generated/AllTriggers.kt
+++ b/script-generator/src/test/kotlin/generated/AllTriggers.kt
@@ -1,7 +1,7 @@
 package generated
 
 import it.krzeminski.githubactions.actions.actions.CheckoutV2
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.BranchProtectionRule
 import it.krzeminski.githubactions.domain.triggers.CheckRun
@@ -151,7 +151,7 @@ public val workflowAllTriggers: Workflow = workflow(
     ) {
       job(
         id = "job-0",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
       ) {
         uses(
           name = "Check out",

--- a/script-generator/src/test/kotlin/generated/DockerImage.kt
+++ b/script-generator/src/test/kotlin/generated/DockerImage.kt
@@ -6,7 +6,7 @@ import it.krzeminski.githubactions.actions.docker.BuildPushActionV2
 import it.krzeminski.githubactions.actions.docker.LoginActionV1
 import it.krzeminski.githubactions.actions.docker.SetupBuildxActionV1
 import it.krzeminski.githubactions.domain.Concurrency
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Push
 import it.krzeminski.githubactions.dsl.expr
@@ -28,7 +28,7 @@ public val workflowDockerImage: Workflow = workflow(
     ) {
       job(
         id = "push_image",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
         concurrency = Concurrency(group = "job_staging_environment", cancelInProgress = true),
       ) {
         uses(

--- a/script-generator/src/test/kotlin/generated/GenerateWrappers.kt
+++ b/script-generator/src/test/kotlin/generated/GenerateWrappers.kt
@@ -4,7 +4,6 @@ import it.krzeminski.githubactions.actions.actions.CheckoutV2
 import it.krzeminski.githubactions.actions.actions.SetupJavaV2
 import it.krzeminski.githubactions.actions.gradle.GradleBuildActionV2
 import it.krzeminski.githubactions.domain.RunnerType
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Push
 import it.krzeminski.githubactions.dsl.ListCustomValue
@@ -27,7 +26,7 @@ public val workflowGenerateWrappers: Workflow = workflow(
     ) {
       job(
         id = "check_yaml_consistency",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
       ) {
         uses(
           name = "Check out",
@@ -46,7 +45,7 @@ public val workflowGenerateWrappers: Workflow = workflow(
 
       job(
         id = "generate-wrappers",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
         _customArguments = mapOf(
         "needs" to ListCustomValue("check_yaml_consistency"),
         )

--- a/script-generator/src/test/kotlin/generated/GeneratedSource.kt
+++ b/script-generator/src/test/kotlin/generated/GeneratedSource.kt
@@ -5,7 +5,6 @@ import it.krzeminski.githubactions.actions.actions.SetupJavaV2
 import it.krzeminski.githubactions.actions.docker.SetupBuildxActionV1
 import it.krzeminski.githubactions.actions.gradle.GradleBuildActionV2
 import it.krzeminski.githubactions.domain.RunnerType
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Cron
 import it.krzeminski.githubactions.domain.triggers.PullRequest
@@ -60,7 +59,7 @@ public val workflowGenerated: Workflow = workflow(
     ) {
       job(
         id = "check_yaml_consistency",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
       ) {
         uses(
           name = "Check out",
@@ -83,7 +82,7 @@ public val workflowGenerated: Workflow = workflow(
 
       job(
         id = "build_for_UbuntuLatest",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
         env = linkedMapOf(
           "COLOR" to "blue",
           "SIZE" to "XXL",

--- a/script-generator/src/test/kotlin/generated/NodeJsPackage.kt
+++ b/script-generator/src/test/kotlin/generated/NodeJsPackage.kt
@@ -3,7 +3,7 @@ package generated
 import it.krzeminski.githubactions.actions.actions.CheckoutV2
 import it.krzeminski.githubactions.actions.actions.SetupNodeV3
 import it.krzeminski.githubactions.domain.Concurrency
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Release
 import it.krzeminski.githubactions.dsl.ListCustomValue
@@ -29,7 +29,7 @@ public val workflowNodejsPackage: Workflow = workflow(
     ) {
       job(
         id = "build",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
         concurrency = Concurrency(group = "job_staging_environment", cancelInProgress = false),
       ) {
         uses(

--- a/script-generator/src/test/kotlin/generated/RefreshversionsBuild.kt
+++ b/script-generator/src/test/kotlin/generated/RefreshversionsBuild.kt
@@ -3,7 +3,7 @@ package generated
 import it.krzeminski.githubactions.actions.actions.CheckoutV2
 import it.krzeminski.githubactions.actions.actions.SetupJavaV2
 import it.krzeminski.githubactions.actions.gradle.GradleBuildActionV2
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.PullRequest
 import it.krzeminski.githubactions.domain.triggers.Push
@@ -81,7 +81,7 @@ public val workflowRefreshversionsBuild: Workflow = workflow(
     ) {
       job(
         id = "check-all",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.Custom(expr("github.event.inputs.run-on || 'ubuntu-latest'")),
       ) {
         run(
           name = "Enable long paths for git Windows",

--- a/script-generator/src/test/kotlin/generated/RefreshversionsPr.kt
+++ b/script-generator/src/test/kotlin/generated/RefreshversionsPr.kt
@@ -6,7 +6,7 @@ import it.krzeminski.githubactions.actions.endbug.AddAndCommitV9
 import it.krzeminski.githubactions.actions.gradle.GradleBuildActionV2
 import it.krzeminski.githubactions.actions.peterjgrainger.ActionCreateBranchV2
 import it.krzeminski.githubactions.actions.reposync.PullRequestV2
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Cron
 import it.krzeminski.githubactions.domain.triggers.Schedule
@@ -30,7 +30,7 @@ public val workflowRefreshversionsPr: Workflow = workflow(
     ) {
       job(
         id = "Refresh-Versions",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
       ) {
         uses(
           name = "check-out",

--- a/script-generator/src/test/kotlin/generated/RefreshversionsWebsite.kt
+++ b/script-generator/src/test/kotlin/generated/RefreshversionsWebsite.kt
@@ -2,7 +2,7 @@ package generated
 
 import it.krzeminski.githubactions.actions.actions.CheckoutV2
 import it.krzeminski.githubactions.actions.actions.SetupPythonV2
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
+import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Push
 import it.krzeminski.githubactions.domain.triggers.WorkflowDispatch
@@ -25,7 +25,7 @@ public val workflowRefreshversionsWebsite: Workflow = workflow(
     ) {
       job(
         id = "deploy",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
       ) {
         uses(
           name = "CheckoutV2",

--- a/script-generator/src/test/kotlin/generated/UpdateGradleWrapper.kt
+++ b/script-generator/src/test/kotlin/generated/UpdateGradleWrapper.kt
@@ -4,7 +4,6 @@ import it.krzeminski.githubactions.actions.CustomAction
 import it.krzeminski.githubactions.actions.actions.CheckoutV2
 import it.krzeminski.githubactions.actions.gradleupdate.UpdateGradleWrapperActionV1
 import it.krzeminski.githubactions.domain.RunnerType
-import it.krzeminski.githubactions.domain.RunnerType.UbuntuLatest
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.domain.triggers.Cron
 import it.krzeminski.githubactions.domain.triggers.Schedule
@@ -30,7 +29,7 @@ public val workflowUpdateGradleWrapper: Workflow = workflow(
     ) {
       job(
         id = "check_yaml_consistency",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
       ) {
         uses(
           name = "Check out",
@@ -50,7 +49,7 @@ public val workflowUpdateGradleWrapper: Workflow = workflow(
 
       job(
         id = "update-gradle-wrapper",
-        runsOn = UbuntuLatest,
+        runsOn = RunnerType.UbuntuLatest,
         _customArguments = mapOf(
         "needs" to ListCustomValue("check_yaml_consistency"),
         )

--- a/script-generator/src/test/kotlin/test/EnumsTest.kt
+++ b/script-generator/src/test/kotlin/test/EnumsTest.kt
@@ -1,15 +1,15 @@
 package test
 
-import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.asClassName
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 import it.krzeminski.githubactions.domain.RunnerType
 import it.krzeminski.githubactions.domain.triggers.PullRequest
-import it.krzeminski.githubactions.scriptgenerator.enumMemberName
 import it.krzeminski.githubactions.scriptmodel.YamlWorkflowTriggers
 import it.krzeminski.githubactions.scriptmodel.myYaml
+import it.krzeminski.githubactions.scriptmodel.runnerTypeBlockOf
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 
@@ -32,11 +32,16 @@ class EnumsTest : FunSpec({
     test("Convert RunnerType") {
         val runnerTypes = listOf(
             RunnerType.UbuntuLatest, RunnerType.WindowsLatest,
-            RunnerType.MacOSLatest, RunnerType.Windows2022, RunnerType.MacOS11
+            RunnerType.MacOSLatest, RunnerType.Windows2022, RunnerType.MacOS11,
         )
         val inputs = listOf("UbuntuLatest", "windows_latest", "mac+os+latest", "windows_2022", "macos 1 1")
         inputs.zip(runnerTypes).forAll { (input, runnerType) ->
-            enumMemberName<RunnerType>(input) shouldBe MemberName(RunnerType::class.asClassName(), runnerType.name)
+            runnerTypeBlockOf(input) shouldBe CodeBlock.of("runsOn = %T,\n", runnerType::class.asClassName())
         }
+        runnerTypeBlockOf("windows-3.0") shouldBe CodeBlock.of("runsOn = it.krzeminski.githubactions.domain.RunnerType.Custom(\"windows-3.0\"),\n")
+
+        runnerTypeBlockOf("${'$'}{{ github.event.inputs.run-on || 'ubuntu-latest' }}") shouldBe CodeBlock.of(
+            "runsOn = it.krzeminski.githubactions.domain.RunnerType.Custom(expr(\"github.event.inputs.run-on || 'ubuntu-latest'\")),\n"
+        )
     }
 })

--- a/script-generator/yaml-output/refreshversions-build.yml
+++ b/script-generator/yaml-output/refreshversions-build.yml
@@ -77,7 +77,7 @@ on:
 
 jobs:
   "check-all":
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ github.event.inputs.run-on || 'ubuntu-latest' }}"
     steps:
       - id: step-0
         name: Enable long paths for git Windows


### PR DESCRIPTION
Resolves #69 

Changes `RunnerType` from an `Enum` to a `sealed class` with an additional `Custom("my-string")` possible value.

This allows do create a runner type from yet-unsupported value and also do use expressions like in

```kotlin
job(runsOn = RunnerType.Custom(expr("github.event.inputs.run-on")))
```

For the user, this changes how the imports work by default

`runsOn = UbuntuLatest`
to
`runsOn = RunnerType.UbuntuLatest`