### PR TITLE
fail-fast when the YAML is malformed

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 dependencies {
     testImplementation("io.kotest:kotest-assertions-core:5.2.3")
     testImplementation("io.kotest:kotest-runner-junit5:5.2.3")
+    implementation("com.charleskorn.kaml:kaml:0.43.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.3.2")
 }
 

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/DetectMalfomedYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/DetectMalfomedYaml.kt
@@ -1,0 +1,25 @@
+package it.krzeminski.githubactions.yaml
+
+import com.charleskorn.kaml.MalformedYamlException
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlConfiguration
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+
+internal fun failIfMalformedYml(yamlContent: String) {
+    try {
+        yaml.decodeFromString<YamlWorkflow>(yamlContent)
+    } catch (e: MalformedYamlException) {
+        println(yamlContent)
+        throw e
+    }
+}
+
+private val yaml = Yaml(
+    configuration = YamlConfiguration(strictMode = false)
+)
+
+@Serializable
+private data class YamlWorkflow(
+    val name: String
+)

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -94,6 +94,8 @@ private fun Workflow.generateYaml(addConsistencyCheck: Boolean, useGitDiff: Bool
                 append("\n")
                 append(freeargs.replaceIndent(""))
             }
+    }.also { yamlContent ->
+        failIfMalformedYml(yamlContent)
     }
 }
 


### PR DESCRIPTION
**What?** 

fail-fast when the YAML is malformed

**Why?**

There are a lots of way to produce invalid YAML with the library.

In this case we should in all cases fail fast instead of letting the user push to GitHub and waste her time.

**How?**

kaml does know whether a given string content is valid YAML or not, so  rely on that.