### PR TITLE
[#151] chore(ci): wait until library present in Maven Central after releasing

### DIFF
--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -40,5 +40,11 @@ val releaseWorkflow = workflow(
                 arguments = ":library:publishToSonatype closeAndReleaseSonatypeStagingRepository",
             )
         )
+        uses(
+            name = "Wait until library present in Maven Central",
+            action = GradleBuildActionV2(
+                arguments = ":library:waitUntilLibraryPresentInMavenCentral",
+            )
+        )
     }
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,3 +46,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :library:publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - id: step-3
+        name: Wait until library present in Maven Central
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :library:waitUntilLibraryPresentInMavenCentral


### PR DESCRIPTION
It's needed to display successful release job status after the library
is really present in Maven Central. Also, after this waiting, some
other things will be released, e.g. the docs.