### PR TITLE
Split integration tests and make them run on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 .idea
 build
+github-actions-integration

--- a/integration.sh
+++ b/integration.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+REPO="https://github.com/jmfayard/github-actions-integration"
+DIR="github-actions-integration"
+YAML="library/src/test/resources/integration/expected"
+TARGET=".github/workflows"
+MESSAGE=$(git log --oneline -n 1 --pretty='format:%s%n%nhttps://github.com/krzema12/github-actions-kotlin-dsl/commit/%H')
+
+test ! -d ${DIR} && {
+  git clone ${REPO}
+  cd ${DIR}
+} || {
+  echo "Pulling main from ${REPO}"
+  cd ${DIR}
+  git stash >/dev/null
+  git pull
+}
+
+echo "Copy files from ${YAML} to ${DIR}/${TARGET}"
+rm -rf ${TARGET:?}/*yml
+rm -rf ${TARGET:?}/*yaml
+cp -f ../${YAML}/* ${TARGET}
+
+git add ${TARGET}
+echo "Changes detected, committing"
+git commit -m "${MESSAGE}"
+echo "Pushing changes to ${REPO}"
+git push --force

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -5,694 +5,98 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.shouldBe
-import it.krzeminski.githubactions.actions.actions.CheckoutV3
-import it.krzeminski.githubactions.actions.endbug.AddAndCommitV9
-import it.krzeminski.githubactions.domain.Concurrency
-import it.krzeminski.githubactions.domain.RunnerType
-import it.krzeminski.githubactions.domain.triggers.Push
-import it.krzeminski.githubactions.dsl.expr
-import it.krzeminski.githubactions.dsl.workflow
+import it.krzeminski.githubactions.integration.workflowConcurrencyCancelInProgress
+import it.krzeminski.githubactions.integration.workflowConcurrencyDefault
+import it.krzeminski.githubactions.integration.workflowEnvironmentVariables
+import it.krzeminski.githubactions.integration.workflowJobCondition
+import it.krzeminski.githubactions.integration.workflowMalformedYaml
+import it.krzeminski.githubactions.integration.workflowStepWithOutputs
+import it.krzeminski.githubactions.integration.workflowTest
+import it.krzeminski.githubactions.integration.workflowWithDependency
+import it.krzeminski.githubactions.integration.workflowWithMultilineCommand
+import it.krzeminski.githubactions.integration.workflowWithTempTargetFile
+import it.krzeminski.githubactions.kotest.setupShouldMatchFile
+import it.krzeminski.githubactions.kotest.shouldMatchFile
 import it.krzeminski.githubactions.yaml.toYaml
 import it.krzeminski.githubactions.yaml.writeToFile
-import java.nio.file.Paths
-import kotlin.io.path.invariantSeparatorsPathString
+import java.io.File
 
-@Suppress("LargeClass")
 class IntegrationTest : FunSpec({
-    val workflow = workflow(
-        name = "Test workflow",
-        on = listOf(Push()),
-        sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-        targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-    ) {
-        job(
-            id = "test_job",
-            name = "Test Job",
-            runsOn = RunnerType.UbuntuLatest,
-        ) {
-            uses(CheckoutV3())
-            run("echo 'hello!'")
-        }
-    }
 
-    test("toYaml() - 'hello world' workflow") {
-        // when
-        val actualYaml = workflow.toYaml()
+    setupShouldMatchFile(
+        baseDirectory = File("src/test/resources/integration"),
+        normalize = { it.replace("\r\n", "\n") }
+    )
 
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-            
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "check_yaml_consistency":
-                runs-on: "ubuntu-latest"
-                steps:
-                  - id: step-0
-                    name: Check out
-                    uses: actions/checkout@v3
-                  - id: step-1
-                    name: Consistency check
-                    run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
-              "test_job":
-                name: Test Job
-                runs-on: "ubuntu-latest"
-                needs:
-                  - "check_yaml_consistency"
-                steps:
-                  - id: step-0
-                    uses: actions/checkout@v3
-                  - id: step-1
-                    run: echo 'hello!'
-
-        """.trimIndent()
+    test("workflowTest : toYaml()") {
+        workflowTest.toYaml() shouldMatchFile "workflowTest.yaml"
     }
 
     test("toYaml() - workflow with one job depending on another") {
-        // given
-        val workflowWithDependency = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-        ) {
-            val testJob1 = job(
-                id = "test_job_1",
-                runsOn = RunnerType.UbuntuLatest,
-            ) {
-                run(
-                    name = "Hello world!",
-                    command = "echo 'hello!'",
-                )
-            }
-
-            job(
-                id = "test_job_2",
-                runsOn = RunnerType.UbuntuLatest,
-                needs = listOf(testJob1),
-            ) {
-                run(
-                    name = "Hello world, again!",
-                    command = "echo 'hello again!'",
-                )
-            }
-        }
-
-        // when
-        val actualYaml = workflowWithDependency.toYaml()
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-            
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "check_yaml_consistency":
-                runs-on: "ubuntu-latest"
-                steps:
-                  - id: step-0
-                    name: Check out
-                    uses: actions/checkout@v3
-                  - id: step-1
-                    name: Consistency check
-                    run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
-              "test_job_1":
-                runs-on: "ubuntu-latest"
-                needs:
-                  - "check_yaml_consistency"
-                steps:
-                  - id: step-0
-                    name: Hello world!
-                    run: echo 'hello!'
-              "test_job_2":
-                runs-on: "ubuntu-latest"
-                needs:
-                  - "test_job_1"
-                  - "check_yaml_consistency"
-                steps:
-                  - id: step-0
-                    name: Hello world, again!
-                    run: echo 'hello again!'
-
-        """.trimIndent()
+        workflowWithDependency.toYaml() shouldMatchFile "workflowWithDependency.yaml"
     }
 
     test("toYaml() - 'hello world' workflow without consistency check") {
-        // when
-        val actualYaml = workflow.toYaml(addConsistencyCheck = false)
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-            
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "test_job":
-                name: Test Job
-                runs-on: "ubuntu-latest"
-                steps:
-                  - id: step-0
-                    uses: actions/checkout@v3
-                  - id: step-1
-                    run: echo 'hello!'
-
-        """.trimIndent()
+        workflowTest.toYaml(addConsistencyCheck = false)
+            .shouldMatchFile("workflowTest-toYaml-consistency.yaml")
     }
 
-    test("toYaml() - multiline command with pipes") {
-        // given
-        val workflowWithMultilineCommand = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-            ) {
-                run(
-                    name = "Hello world!",
-                    command = """
-                        less test.txt \
-                        | grep -P "foobar" \
-                        | sort \
-                        > result.txt
-                    """.trimIndent(),
-                )
-            }
-        }
-
-        // when
-        val actualYaml = workflowWithMultilineCommand.toYaml(addConsistencyCheck = false)
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "test_job":
-                runs-on: "ubuntu-latest"
-                steps:
-                  - id: step-0
-                    name: Hello world!
-                    run: |
-                      less test.txt \
-                      | grep -P "foobar" \
-                      | sort \
-                      > result.txt
-
-        """.trimIndent()
+    test("workflowWithMultilineCommand - multiline command with pipes") {
+        workflowWithMultilineCommand.toYaml(addConsistencyCheck = false)
+            .shouldMatchFile("workflowWithMultilineCommand.yaml")
     }
 
-    test("writeToFile() - 'hello world' workflow") {
+    test("workflowWithTempTargetFile - no consistency") {
         // given
         val targetTempFile = tempfile()
-        val workflowWithTempTargetFile = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = targetTempFile.toPath(),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-            ) {
-                uses(
-                    name = "Check out",
-                    action = CheckoutV3(),
-                )
-
-                run(
-                    name = "Hello world!",
-                    command = "echo 'hello!'",
-                )
-            }
-        }
 
         // when
-        workflowWithTempTargetFile.writeToFile(addConsistencyCheck = false)
+        workflowWithTempTargetFile(targetTempFile).writeToFile(addConsistencyCheck = false)
 
         // then
-        targetTempFile.readText() shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "test_job":
-                runs-on: "ubuntu-latest"
-                steps:
-                  - id: step-0
-                    name: Check out
-                    uses: actions/checkout@v3
-                  - id: step-1
-                    name: Hello world!
-                    run: echo 'hello!'
-
-        """.trimIndent()
+        targetTempFile.readText() shouldMatchFile "workflowWithTempTargetFile.yaml"
     }
 
-    test("writeToFile(addConsistencyCheck = true) - 'hello world' workflow") {
+    test("workflowWithTempTargetFile - consistency") {
         // given
         val targetTempFile = tempfile()
-        val workflowWithTempTargetFile = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = targetTempFile.toPath(),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-            ) {
-                uses(
-                    name = "Check out",
-                    action = CheckoutV3(),
-                )
-
-                run(
-                    name = "Hello world!",
-                    command = "echo 'hello!'",
-                )
-            }
-        }
+        val workflowWithTempTargetFile = workflowWithTempTargetFile(tempfile())
 
         // when
         workflowWithTempTargetFile.writeToFile(addConsistencyCheck = true)
 
         // then
-        val targetPath = targetTempFile.toPath().invariantSeparatorsPathString
-        targetTempFile.readText() shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-            
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "check_yaml_consistency":
-                runs-on: "ubuntu-latest"
-                steps:
-                  - id: step-0
-                    name: Check out
-                    uses: actions/checkout@v3
-                  - id: step-1
-                    name: Execute script
-                    run: rm '$targetPath' && '.github/workflows/some_workflow.main.kts'
-                  - id: step-2
-                    name: Consistency check
-                    run: git diff --exit-code '$targetPath'
-              "test_job":
-                runs-on: "ubuntu-latest"
-                needs:
-                  - "check_yaml_consistency"
-                steps:
-                  - id: step-0
-                    name: Check out
-                    uses: actions/checkout@v3
-                  - id: step-1
-                    name: Hello world!
-                    run: echo 'hello!'
-
-        """.trimIndent()
+        targetTempFile.readText() shouldMatchFile "workflowWithTempTargetFile-consistency.yaml"
     }
 
-    test("toYaml() - job condition") {
-        // when
-        val actualYaml = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-                condition = "\${{ always() }}"
-            ) {
-                uses(
-                    name = "Check out",
-                    action = CheckoutV3(),
-                )
-            }
-        }.toYaml(addConsistencyCheck = false)
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-            
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "test_job":
-                runs-on: "ubuntu-latest"
-                if: ${'$'}{{ always() }}
-                steps:
-                  - id: step-0
-                    name: Check out
-                    uses: actions/checkout@v3
-
-        """.trimIndent()
+    test("workflowJobCondition") {
+        workflowJobCondition.toYaml(addConsistencyCheck = false) shouldMatchFile "workflowJobCondition.yaml"
     }
 
-    test("toYaml() - environment variables") {
-        // when
-        val actualYaml = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            env = linkedMapOf(
-                "SIMPLE_VAR" to "simple-value-workflow",
-                "MULTILINE_VAR" to """
-                    hey,
-                    hi,
-                    hello! workflow
-                """.trimIndent()
-            ),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-                condition = "\${{ always() }}",
-                env = linkedMapOf(
-                    "SIMPLE_VAR" to "simple-value-job",
-                    "MULTILINE_VAR" to """
-                        hey,
-                        hi,
-                        hello! job
-                    """.trimIndent()
-                ),
-            ) {
-                uses(
-                    name = "Check out",
-                    action = CheckoutV3(),
-                    env = linkedMapOf(
-                        "SIMPLE_VAR" to "simple-value-uses",
-                        "MULTILINE_VAR" to """
-                            hey,
-                            hi,
-                            hello! uses
-                        """.trimIndent()
-                    ),
-                )
-
-                run(
-                    name = "Hello world!",
-                    command = "echo 'hello!'",
-                    env = linkedMapOf(
-                        "SIMPLE_VAR" to "simple-value-run",
-                        "MULTILINE_VAR" to """
-                            hey,
-                            hi,
-                            hello! run
-                        """.trimIndent()
-                    ),
-                )
-            }
-        }.toYaml(addConsistencyCheck = false)
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-            
-            name: Test workflow
-
-            on:
-              push:
-
-            env:
-              SIMPLE_VAR: simple-value-workflow
-              MULTILINE_VAR: |
-                hey,
-                hi,
-                hello! workflow
-
-            jobs:
-              "test_job":
-                runs-on: "ubuntu-latest"
-                env:
-                  SIMPLE_VAR: simple-value-job
-                  MULTILINE_VAR: |
-                    hey,
-                    hi,
-                    hello! job
-                if: ${'$'}{{ always() }}
-                steps:
-                  - id: step-0
-                    name: Check out
-                    uses: actions/checkout@v3
-                    env:
-                      SIMPLE_VAR: simple-value-uses
-                      MULTILINE_VAR: |
-                        hey,
-                        hi,
-                        hello! uses
-                  - id: step-1
-                    name: Hello world!
-                    env:
-                      SIMPLE_VAR: simple-value-run
-                      MULTILINE_VAR: |
-                        hey,
-                        hi,
-                        hello! run
-                    run: echo 'hello!'
-
-        """.trimIndent()
+    test("workflowEnvironmentVariables") {
+        workflowEnvironmentVariables.toYaml(addConsistencyCheck = false)
+            .shouldMatchFile("workflowEnvironmentVariables.yaml")
     }
 
-    test("toYaml() - step with outputs") {
-        // when
-        val actualYaml = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-            ) {
-                val addAndCommit = uses(AddAndCommitV9())
-
-                uses(
-                    name = "Some step consuming other step's output",
-                    action = CheckoutV3(
-                        repository = expr(addAndCommit.id),
-                        ref = expr(addAndCommit.outputs.commitSha),
-                        token = expr(addAndCommit.outputs["my-unsafe-output"]),
-                    )
-                )
-            }
-        }.toYaml(addConsistencyCheck = false)
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-
-            name: Test workflow
-
-            on:
-              push:
-
-            jobs:
-              "test_job":
-                runs-on: "ubuntu-latest"
-                steps:
-                  - id: step-0
-                    uses: EndBug/add-and-commit@v9
-                  - id: step-1
-                    name: Some step consuming other step's output
-                    uses: actions/checkout@v3
-                    with:
-                      repository: ${'$'}{{ step-0 }}
-                      ref: ${'$'}{{ steps.step-0.outputs.commit_sha }}
-                      token: ${'$'}{{ steps.step-0.outputs.my-unsafe-output }}
-
-        """.trimIndent()
+    test("workflowStepWithOutputs") {
+        workflowStepWithOutputs.toYaml(addConsistencyCheck = false)
+            .shouldMatchFile("workflowStepWithOutputs.yaml")
     }
 
-    test("toYaml() - with concurrency, default behavior") {
-        // when
-        val actualYaml = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-            concurrency = Concurrency("workflow_staging_environment"),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-                concurrency = Concurrency("job_staging_environment"),
-            ) {
-                val addAndCommit = uses(AddAndCommitV9())
-
-                uses(
-                    name = "Some step consuming other step's output",
-                    action = CheckoutV3(
-                        repository = expr(addAndCommit.id),
-                        ref = expr(addAndCommit.outputs.commitSha),
-                        token = expr(addAndCommit.outputs["my-unsafe-output"]),
-                    )
-                )
-            }
-        }.toYaml(addConsistencyCheck = false)
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-
-            name: Test workflow
-            
-            on:
-              push:
-
-            concurrency:
-              group: workflow_staging_environment
-              cancel-in-progress: false
-
-            jobs:
-              "test_job":
-                runs-on: "ubuntu-latest"
-                concurrency:
-                  group: job_staging_environment
-                  cancel-in-progress: false
-                steps:
-                  - id: step-0
-                    uses: EndBug/add-and-commit@v9
-                  - id: step-1
-                    name: Some step consuming other step's output
-                    uses: actions/checkout@v3
-                    with:
-                      repository: ${'$'}{{ step-0 }}
-                      ref: ${'$'}{{ steps.step-0.outputs.commit_sha }}
-                      token: ${'$'}{{ steps.step-0.outputs.my-unsafe-output }}
-
-        """.trimIndent()
+    test("workflowConcurrencyDefault") {
+        workflowConcurrencyDefault.toYaml(addConsistencyCheck = false)
+            .shouldMatchFile("workflowConcurrencyDefault.yaml")
     }
 
-    test("toYaml() - with concurrency, cancel in progress") {
-        // when
-        val actualYaml = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
-            targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
-            concurrency = Concurrency("workflow_staging_environment", cancelInProgress = true),
-        ) {
-            job(
-                id = "test_job",
-                runsOn = RunnerType.UbuntuLatest,
-                concurrency = Concurrency("job_staging_environment", cancelInProgress = true),
-            ) {
-                val addAndCommit = uses(AddAndCommitV9())
-
-                uses(
-                    name = "Some step consuming other step's output",
-                    action = CheckoutV3(
-                        repository = expr(addAndCommit.id),
-                        ref = expr(addAndCommit.outputs.commitSha),
-                        token = expr(addAndCommit.outputs["my-unsafe-output"]),
-                    )
-                )
-            }
-        }.toYaml(addConsistencyCheck = false)
-
-        // then
-        actualYaml shouldBe """
-            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
-            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
-            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
-
-            name: Test workflow
-            
-            on:
-              push:
-
-            concurrency:
-              group: workflow_staging_environment
-              cancel-in-progress: true
-
-            jobs:
-              "test_job":
-                runs-on: "ubuntu-latest"
-                concurrency:
-                  group: job_staging_environment
-                  cancel-in-progress: true
-                steps:
-                  - id: step-0
-                    uses: EndBug/add-and-commit@v9
-                  - id: step-1
-                    name: Some step consuming other step's output
-                    uses: actions/checkout@v3
-                    with:
-                      repository: ${'$'}{{ step-0 }}
-                      ref: ${'$'}{{ steps.step-0.outputs.commit_sha }}
-                      token: ${'$'}{{ steps.step-0.outputs.my-unsafe-output }}
-
-        """.trimIndent()
+    test("workflowConcurrencyCancelInProgress") {
+        workflowConcurrencyCancelInProgress.toYaml(addConsistencyCheck = false)
+            .shouldMatchFile("workflowConcurrencyCancelInProgress.yaml")
     }
 
-    test("Malformed YAML") {
+    test("workflowMalformedYaml") {
 
-        val invalidWorkflow = workflow(
-            name = "Test workflow",
-            on = listOf(Push()),
-            sourceFile = Paths.get("../.github/workflows/invalid_workflow.main.kts"),
-            targetFile = Paths.get("../.github/workflows/invalid_workflow.yaml"),
-        ) {
-            job("test_job", runsOn = RunnerType.UbuntuLatest) {
-                run(name = "property: something", command = "echo hello")
-            }
-        }
         shouldThrow<MalformedYamlException> {
-            invalidWorkflow.toYaml()
+            workflowMalformedYaml.toYaml()
         }.message shouldBe """
             |mapping values are not allowed here (is the indentation level of this line or a line nearby incorrect?)
             | at line 26, column 23:

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowConcurrencyCancelInProgress.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowConcurrencyCancelInProgress.kt
@@ -1,0 +1,35 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.actions.endbug.AddAndCommitV9
+import it.krzeminski.githubactions.domain.Concurrency
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.expr
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowConcurrencyCancelInProgress = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+    concurrency = Concurrency("workflow_staging_environment", cancelInProgress = true),
+) {
+    job(
+        id = "test_job",
+        runsOn = RunnerType.UbuntuLatest,
+        concurrency = Concurrency("job_staging_environment", cancelInProgress = true),
+    ) {
+        val addAndCommit = uses(AddAndCommitV9())
+
+        uses(
+            name = "Some step consuming other step's output",
+            action = CheckoutV3(
+                repository = expr(addAndCommit.id),
+                ref = expr(addAndCommit.outputs.commitSha),
+                token = expr(addAndCommit.outputs["my-unsafe-output"]),
+            )
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowConcurrencyDefault.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowConcurrencyDefault.kt
@@ -1,0 +1,35 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.actions.endbug.AddAndCommitV9
+import it.krzeminski.githubactions.domain.Concurrency
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.expr
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowConcurrencyDefault = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+    concurrency = Concurrency("workflow_staging_environment"),
+) {
+    job(
+        id = "test_job",
+        runsOn = RunnerType.UbuntuLatest,
+        concurrency = Concurrency("job_staging_environment"),
+    ) {
+        val addAndCommit = uses(AddAndCommitV9())
+
+        uses(
+            name = "Some step consuming other step's output",
+            action = CheckoutV3(
+                repository = expr(addAndCommit.id),
+                ref = expr(addAndCommit.outputs.commitSha),
+                token = expr(addAndCommit.outputs["my-unsafe-output"]),
+            )
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowEnvironmentVariables.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowEnvironmentVariables.kt
@@ -1,0 +1,62 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowEnvironmentVariables = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    env = linkedMapOf(
+        "SIMPLE_VAR" to "simple-value-workflow",
+        "MULTILINE_VAR" to """
+                    hey,
+                    hi,
+                    hello! workflow
+        """.trimIndent()
+    ),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+) {
+    job(
+        id = "test_job",
+        runsOn = RunnerType.UbuntuLatest,
+        condition = "\${{ always() }}",
+        env = linkedMapOf(
+            "SIMPLE_VAR" to "simple-value-job",
+            "MULTILINE_VAR" to """
+                        hey,
+                        hi,
+                        hello! job
+            """.trimIndent()
+        ),
+    ) {
+        uses(
+            name = "Check out",
+            action = CheckoutV3(),
+            env = linkedMapOf(
+                "SIMPLE_VAR" to "simple-value-uses",
+                "MULTILINE_VAR" to """
+                            hey,
+                            hi,
+                            hello! uses
+                """.trimIndent()
+            ),
+        )
+
+        run(
+            name = "Hello world!",
+            command = "echo 'hello!'",
+            env = linkedMapOf(
+                "SIMPLE_VAR" to "simple-value-run",
+                "MULTILINE_VAR" to """
+                            hey,
+                            hi,
+                            hello! run
+                """.trimIndent()
+            ),
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowJobCondition.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowJobCondition.kt
@@ -1,0 +1,25 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowJobCondition = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+) {
+    job(
+        id = "test_job",
+        runsOn = RunnerType.UbuntuLatest,
+        condition = "\${{ always() }}"
+    ) {
+        uses(
+            name = "Check out",
+            action = CheckoutV3(),
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowMalformedYaml.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowMalformedYaml.kt
@@ -1,0 +1,17 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowMalformedYaml = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get("../.github/workflows/invalid_workflow.main.kts"),
+    targetFile = Paths.get("../.github/workflows/invalid_workflow.yaml"),
+) {
+    job("test_job", runsOn = RunnerType.UbuntuLatest) {
+        run(name = "property: something", command = "echo hello")
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowStepWithOutputs.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowStepWithOutputs.kt
@@ -1,0 +1,32 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.actions.endbug.AddAndCommitV9
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.expr
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowStepWithOutputs = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+) {
+    job(
+        id = "test_job",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        val addAndCommit = uses(AddAndCommitV9())
+
+        uses(
+            name = "Some step consuming other step's output",
+            action = CheckoutV3(
+                repository = expr(addAndCommit.id),
+                ref = expr(addAndCommit.outputs.commitSha),
+                token = expr(addAndCommit.outputs["my-unsafe-output"]),
+            )
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowTest.kt
@@ -1,0 +1,23 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowTest = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+) {
+    job(
+        id = "test_job",
+        name = "Test Job",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        uses(CheckoutV3())
+        run("echo 'hello!'")
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowWithDependency.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowWithDependency.kt
@@ -1,0 +1,34 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowWithDependency = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+) {
+    val testJob1 = job(
+        id = "test_job_1",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        run(
+            name = "Hello world!",
+            command = "echo 'hello!'",
+        )
+    }
+
+    job(
+        id = "test_job_2",
+        runsOn = RunnerType.UbuntuLatest,
+        needs = listOf(testJob1),
+    ) {
+        run(
+            name = "Hello world, again!",
+            command = "echo 'hello again!'",
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowWithMultilineCommand.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowWithMultilineCommand.kt
@@ -1,0 +1,28 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import java.nio.file.Paths
+
+val workflowWithMultilineCommand = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = Paths.get(".github/workflows/some_workflow.yaml"),
+) {
+    job(
+        id = "test_job",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        run(
+            name = "Hello world!",
+            command = """
+                        less test.txt \
+                        | grep -P "foobar" \
+                        | sort \
+                        > result.txt
+            """.trimIndent(),
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowWithTempTargetFile.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/integration/WorkflowWithTempTargetFile.kt
@@ -1,0 +1,30 @@
+package it.krzeminski.githubactions.integration
+
+import it.krzeminski.githubactions.actions.actions.CheckoutV3
+import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.dsl.workflow
+import java.io.File
+import java.nio.file.Paths
+
+fun workflowWithTempTargetFile(targetTempFile: File) = workflow(
+    name = "Test workflow",
+    on = listOf(Push()),
+    sourceFile = Paths.get(".github/workflows/some_workflow.main.kts"),
+    targetFile = targetTempFile.toPath(),
+) {
+    job(
+        id = "test_job",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        uses(
+            name = "Check out",
+            action = CheckoutV3(),
+        )
+
+        run(
+            name = "Hello world!",
+            command = "echo 'hello!'",
+        )
+    }
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/kotest/ShouldMatchFile.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/kotest/ShouldMatchFile.kt
@@ -1,0 +1,43 @@
+package it.krzeminski.githubactions.kotest
+
+import io.kotest.assertions.fail
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+fun setupShouldMatchFile(
+    baseDirectory: File = File("src/test/resources"),
+    normalize: (String) -> String = { it },
+) {
+    settingsBaseDirectory = baseDirectory
+    settingsNormalizeString = normalize
+    baseDirectory.resolve("actual").deleteRecursively()
+    baseDirectory.resolve("actual").mkdirs()
+}
+
+private var settingsBaseDirectory = File("src/test/resources")
+private var settingsNormalizeString: (String) -> String = { it }
+
+infix fun String.shouldMatchFile(path: String) {
+    val expectedFile = settingsBaseDirectory.resolve("expected/$path")
+    val actualFile = settingsBaseDirectory.resolve("actual/$path")
+
+    val actual = settingsNormalizeString(this)
+    val expected = when {
+        expectedFile.canRead().not() -> ""
+        else -> settingsNormalizeString(expectedFile.readText())
+    }
+
+    if (System.getenv("GITHUB_ACTIONS") == "true") {
+        actual shouldBe expected
+    } else if (actual == expected) {
+        actualFile.delete()
+    } else {
+        actualFile.writeText(actual)
+        fail(
+            """
+            |Files differ in ${settingsBaseDirectory.canonicalPath}
+            |Expected: ${expectedFile.relativeTo(settingsBaseDirectory)}
+            |Actual:     ${actualFile.relativeTo(settingsBaseDirectory)} """.trimMargin()
+        )
+    }
+}

--- a/library/src/test/resources/integration/expected/some_workflow.yaml
+++ b/library/src/test/resources/integration/expected/some_workflow.yaml
@@ -1,0 +1,12 @@
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "check_yaml_consistency":
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        name: Check out
+        uses: actions/checkout@v3

--- a/library/src/test/resources/integration/expected/workflowConcurrencyCancelInProgress.yaml
+++ b/library/src/test/resources/integration/expected/workflowConcurrencyCancelInProgress.yaml
@@ -1,0 +1,29 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+concurrency:
+  group: workflow_staging_environment
+  cancel-in-progress: true
+
+jobs:
+  "test_job":
+    runs-on: "ubuntu-latest"
+    concurrency:
+      group: job_staging_environment
+      cancel-in-progress: true
+    steps:
+      - id: step-0
+        uses: EndBug/add-and-commit@v9
+      - id: step-1
+        name: Some step consuming other step's output
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ step-0 }}
+          ref: ${{ steps.step-0.outputs.commit_sha }}
+          token: ${{ steps.step-0.outputs.my-unsafe-output }}

--- a/library/src/test/resources/integration/expected/workflowConcurrencyDefault.yaml
+++ b/library/src/test/resources/integration/expected/workflowConcurrencyDefault.yaml
@@ -1,0 +1,29 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+concurrency:
+  group: workflow_staging_environment
+  cancel-in-progress: false
+
+jobs:
+  "test_job":
+    runs-on: "ubuntu-latest"
+    concurrency:
+      group: job_staging_environment
+      cancel-in-progress: false
+    steps:
+      - id: step-0
+        uses: EndBug/add-and-commit@v9
+      - id: step-1
+        name: Some step consuming other step's output
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ step-0 }}
+          ref: ${{ steps.step-0.outputs.commit_sha }}
+          token: ${{ steps.step-0.outputs.my-unsafe-output }}

--- a/library/src/test/resources/integration/expected/workflowEnvironmentVariables.yaml
+++ b/library/src/test/resources/integration/expected/workflowEnvironmentVariables.yaml
@@ -1,0 +1,45 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+env:
+  SIMPLE_VAR: simple-value-workflow
+  MULTILINE_VAR: |
+    hey,
+    hi,
+    hello! workflow
+
+jobs:
+  "test_job":
+    runs-on: "ubuntu-latest"
+    env:
+      SIMPLE_VAR: simple-value-job
+      MULTILINE_VAR: |
+        hey,
+        hi,
+        hello! job
+    if: ${{ always() }}
+    steps:
+      - id: step-0
+        name: Check out
+        uses: actions/checkout@v3
+        env:
+          SIMPLE_VAR: simple-value-uses
+          MULTILINE_VAR: |
+            hey,
+            hi,
+            hello! uses
+      - id: step-1
+        name: Hello world!
+        env:
+          SIMPLE_VAR: simple-value-run
+          MULTILINE_VAR: |
+            hey,
+            hi,
+            hello! run
+        run: echo 'hello!'

--- a/library/src/test/resources/integration/expected/workflowJobCondition.yaml
+++ b/library/src/test/resources/integration/expected/workflowJobCondition.yaml
@@ -1,0 +1,17 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "test_job":
+    runs-on: "ubuntu-latest"
+    if: ${{ always() }}
+    steps:
+      - id: step-0
+        name: Check out
+        uses: actions/checkout@v3

--- a/library/src/test/resources/integration/expected/workflowStepWithOutputs.yaml
+++ b/library/src/test/resources/integration/expected/workflowStepWithOutputs.yaml
@@ -1,0 +1,22 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "test_job":
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        uses: EndBug/add-and-commit@v9
+      - id: step-1
+        name: Some step consuming other step's output
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ step-0 }}
+          ref: ${{ steps.step-0.outputs.commit_sha }}
+          token: ${{ steps.step-0.outputs.my-unsafe-output }}

--- a/library/src/test/resources/integration/expected/workflowTest-toYaml-consistency.yaml
+++ b/library/src/test/resources/integration/expected/workflowTest-toYaml-consistency.yaml
@@ -1,0 +1,18 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "test_job":
+    name: Test Job
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        uses: actions/checkout@v3
+      - id: step-1
+        run: echo 'hello!'

--- a/library/src/test/resources/integration/expected/workflowTest-toYaml.yaml
+++ b/library/src/test/resources/integration/expected/workflowTest-toYaml.yaml
@@ -1,0 +1,23 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dslname: Test workflowon:
+  push:jobs:
+  "check_yaml_consistency":
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        name: Check out
+        uses: actions/checkout@v3
+      - id: step-1
+        name: Consistency check
+        run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
+  "test_job":
+    name: Test Job
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check_yaml_consistency"
+    steps:
+      - id: step-0
+        uses: actions/checkout@v3
+      - id: step-1
+        run: echo 'hello!'

--- a/library/src/test/resources/integration/expected/workflowTest.yaml
+++ b/library/src/test/resources/integration/expected/workflowTest.yaml
@@ -1,0 +1,29 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "check_yaml_consistency":
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        name: Check out
+        uses: actions/checkout@v3
+      - id: step-1
+        name: Consistency check
+        run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
+  "test_job":
+    name: Test Job
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check_yaml_consistency"
+    steps:
+      - id: step-0
+        uses: actions/checkout@v3
+      - id: step-1
+        run: echo 'hello!'

--- a/library/src/test/resources/integration/expected/workflowWithDependency.yaml
+++ b/library/src/test/resources/integration/expected/workflowWithDependency.yaml
@@ -1,0 +1,36 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "check_yaml_consistency":
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        name: Check out
+        uses: actions/checkout@v3
+      - id: step-1
+        name: Consistency check
+        run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
+  "test_job_1":
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check_yaml_consistency"
+    steps:
+      - id: step-0
+        name: Hello world!
+        run: echo 'hello!'
+  "test_job_2":
+    runs-on: "ubuntu-latest"
+    needs:
+      - "test_job_1"
+      - "check_yaml_consistency"
+    steps:
+      - id: step-0
+        name: Hello world, again!
+        run: echo 'hello again!'

--- a/library/src/test/resources/integration/expected/workflowWithMultilineCommand.yaml
+++ b/library/src/test/resources/integration/expected/workflowWithMultilineCommand.yaml
@@ -1,0 +1,20 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "test_job":
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        name: Hello world!
+        run: |
+          less test.txt \
+          | grep -P "foobar" \
+          | sort \
+          > result.txt

--- a/library/src/test/resources/integration/expected/workflowWithTempTargetFile.yaml
+++ b/library/src/test/resources/integration/expected/workflowWithTempTargetFile.yaml
@@ -1,0 +1,19 @@
+# This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+name: Test workflow
+
+on:
+  push:
+
+jobs:
+  "test_job":
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: step-0
+        name: Check out
+        uses: actions/checkout@v3
+      - id: step-1
+        name: Hello world!
+        run: echo 'hello!'


### PR DESCRIPTION
Solves #87 

Each workflow from `IntegrationTest` is defined in its own file.

Each expected YAML is defined in resources/integration/expected/$NAME.yaml

If the test fails, the actual YAML is written to resources/integration/actual/$NAME.yaml

Add a new workflow who copy the YAML worklows to a separate repository;

The shell script `./integration.sh` commit those YAML files to https://github.com/jmfayard/github-actions-integration and pushes to that repo where the workflows are run. Which also means our integration test should have a `Push()` trigger

TODO @krzema12 : fork my repo https://github.com/jmfayard/github-actions-integration  and update the shell script `./integration.sh`

---

Note: initially I wanted to copy the YAML files via a GitHub workflow.  Unfortunately it is forbidden by GitHub to push YAML files inside `.github/workflows`, probably to avoid infinite loops. See https://github.com/EndBug/add-and-commit/issues/342
