### PR TITLE
[#248] feat(wrappers): use v1 for bahmutov/npm-install

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -51,7 +51,7 @@ Click on a version to see the wrapper's code.
     * [login](https://github.com/Azure/login) - v1: [`LoginV1`](https://github.com/krzema12/github-actions-kotlin-dsl/blob/v{{ version }}/library/src/gen/kotlin/it/krzeminski/githubactions/actions/azure/LoginV1.kt)
     * [webapps-deploy](https://github.com/Azure/webapps-deploy) - v2: [`WebappsDeployV2`](https://github.com/krzema12/github-actions-kotlin-dsl/blob/v{{ version }}/library/src/gen/kotlin/it/krzeminski/githubactions/actions/azure/WebappsDeployV2.kt)
 * bahmutov
-    * [npm-install](https://github.com/bahmutov/npm-install) - v1.8.12: [`NpmInstallV1`](https://github.com/krzema12/github-actions-kotlin-dsl/blob/v{{ version }}/library/src/gen/kotlin/it/krzeminski/githubactions/actions/bahmutov/NpmInstallV1.kt)
+    * [npm-install](https://github.com/bahmutov/npm-install) - v1: [`NpmInstallV1`](https://github.com/krzema12/github-actions-kotlin-dsl/blob/v{{ version }}/library/src/gen/kotlin/it/krzeminski/githubactions/actions/bahmutov/NpmInstallV1.kt)
 * Borales
     * [actions-yarn](https://github.com/Borales/actions-yarn) - v2.3.0: [`ActionsYarnV2`](https://github.com/krzema12/github-actions-kotlin-dsl/blob/v{{ version }}/library/src/gen/kotlin/it/krzeminski/githubactions/actions/borales/ActionsYarnV2.kt)
 * cachix

--- a/library/src/gen/kotlin/it/krzeminski/githubactions/actions/bahmutov/NpmInstallV1.kt
+++ b/library/src/gen/kotlin/it/krzeminski/githubactions/actions/bahmutov/NpmInstallV1.kt
@@ -45,7 +45,7 @@ public class NpmInstallV1(
      * version that the wrapper doesn't yet know about
      */
     _customVersion: String? = null,
-) : Action("bahmutov", "npm-install", _customVersion ?: "v1.8.12") {
+) : Action("bahmutov", "npm-install", _customVersion ?: "v1") {
     @Suppress("SpreadOperator")
     public override fun toYamlArguments() = linkedMapOf(
         *listOfNotNull(

--- a/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
+++ b/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt
@@ -437,7 +437,7 @@ val wrappersToGenerate = listOf(
         )
     ),
     WrapperRequest(
-        ActionCoords("bahmutov", "npm-install", "v1.8.12"),
+        ActionCoords("bahmutov", "npm-install", "v1"),
         mapOf(
             "useLockFile" to BooleanTyping,
             "useRollingCache" to BooleanTyping,


### PR DESCRIPTION
Using version up to patch number causes a need to update it frequently.
I discovered that this action does expose a major version but through
a branch, not a tag. Only tags are checked by the job that looks for
newer versions. This pontential room for improvement is tracked in #250.