### PR TITLE
fix(script-generator): expr(String) is in a new package

### DIFF
--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/GitHubWorkflow.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/GitHubWorkflow.kt
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 
 fun YamlWorkflow.toFileSpec(filenameFromUrl: String?) = FileSpec.builder("", "$name.main.kts")
     .addImport("$PACKAGE.yaml", "toYaml", "writeToFile")
-    .addImport("$PACKAGE.dsl", "expr")
+    .addImport("$PACKAGE.dsl.expressions", "expr")
     .addProperty(workFlowProperty(filenameFromUrl))
     .build()
 

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/Members.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/Members.kt
@@ -3,7 +3,6 @@ package it.krzeminski.githubactions.scriptgenerator
 import com.squareup.kotlinpoet.MemberName
 
 object Members {
-    val expr = MemberName("$PACKAGE.dsl", "expr")
     val workflow = MemberName("$PACKAGE.dsl", "workflow")
     val linkedMapOf = MemberName("kotlin.collections", "linkedMapOf")
     val mapOf = MemberName("kotlin.collections", "mapOf")

--- a/script-generator/src/test/kotlin/it/krzeminski/githubactions/scriptgenerator/ImportsTest.kt
+++ b/script-generator/src/test/kotlin/it/krzeminski/githubactions/scriptgenerator/ImportsTest.kt
@@ -1,0 +1,45 @@
+package it.krzeminski.githubactions.scriptgenerator
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.booleans.shouldBeTrue
+import it.krzeminski.githubactions.domain.triggers.Push
+import it.krzeminski.githubactions.scriptmodel.YamlJob
+import it.krzeminski.githubactions.scriptmodel.YamlStep
+import it.krzeminski.githubactions.scriptmodel.YamlWorkflow
+import it.krzeminski.githubactions.scriptmodel.YamlWorkflowTriggers
+
+class ImportsTest : FunSpec({
+
+    val expectedImports = """
+        |import it.krzeminski.githubactions.domain.RunnerType
+        |import it.krzeminski.githubactions.domain.Workflow
+        |import it.krzeminski.githubactions.domain.triggers.Push
+        |import it.krzeminski.githubactions.dsl.expressions.expr
+        |import it.krzeminski.githubactions.dsl.workflow
+        |import it.krzeminski.githubactions.yaml.toYaml
+        |import it.krzeminski.githubactions.yaml.writeToFile
+        |import java.nio.`file`.Paths
+    """.trimMargin().lines()
+
+    val workflow = YamlWorkflow(
+        name = "hello",
+        on = YamlWorkflowTriggers(Push()),
+        jobs = mapOf(
+            "job" to YamlJob(
+                runsOn = "Unbuntu-Latest",
+                steps = listOf(
+                    YamlStep(id = "step", run = "run it")
+                )
+            )
+        )
+    )
+
+    test("Check for correct imports") {
+        val content = workflow.toFileSpec("filename").toString()
+        println(content)
+        expectedImports.forAll { import ->
+            content.contains(import).shouldBeTrue()
+        }
+    }
+})


### PR DESCRIPTION
Hello I noticed a bug in the script-generator while working on my article

There is currently a compile error when you use it because ´expr(String)`  has moved from package `dsl.expr` to `dsl.expressions.expr`