### PR TITLE
Workflow and Job defaults Parameter

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Defaults.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Defaults.kt
@@ -1,0 +1,16 @@
+package it.krzeminski.githubactions.domain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Defaults(
+    val run: Run,
+)
+
+@Serializable
+data class Run(
+    val shell: String? = null,
+    @SerialName("working-directory")
+    val workingDirectory: String? = null
+)

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Defaults.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Defaults.kt
@@ -3,14 +3,33 @@ package it.krzeminski.githubactions.domain
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Use defaults to create a map of default settings that will apply to all jobs in the workflow.
+ *
+ * You can also set default settings that are only available to a job. For more information, see jobs.<job_id>.defaults.
+ *
+ * See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaults
+ * See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun
+ */
 @Serializable
 data class Defaults(
     val run: Run,
 )
 
+/**
+ * You can use defaults.run to provide default shell and working-directory options for all run steps in a workflow.
+ *
+ * See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
+ */
 @Serializable
 data class Run(
     val shell: String? = null,
     @SerialName("working-directory")
     val workingDirectory: String? = null
 )
+
+fun Run.requireAtLeastOneInput() {
+    require(this.shell != null || this.workingDirectory != null) {
+        "Run should at least have one of shell or working-directory defined!"
+    }
+}

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Job.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Job.kt
@@ -8,6 +8,7 @@ data class Job(
     val id: String,
     val name: String? = null,
     val runsOn: RunnerType,
+    val defaults: Defaults? = null,
     val steps: List<Step>,
     val needs: List<Job> = emptyList(),
     val env: LinkedHashMap<String, String> = linkedMapOf(),
@@ -24,6 +25,9 @@ data class Job(
             regex = Regex("[a-zA-Z_][a-zA-Z0-9_-]*"),
             url = "https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#setting-an-id-for-a-job"
         )
+        defaults?.let {
+            defaults.run.requireAtLeastOneInput()
+        }
         timeoutMinutes?.let { value ->
             require(value > 0) { "timeout should be positive" }
         }

--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
@@ -11,6 +11,7 @@ data class Workflow(
     val env: LinkedHashMap<String, String>,
     val sourceFile: Path,
     val targetFileName: String,
+    val defaults: Defaults? = null,
     val concurrency: Concurrency? = null,
     val jobs: List<Job>,
     override val _customArguments: Map<String, CustomValue> = mapOf(),

--- a/library/src/main/kotlin/it/krzeminski/githubactions/dsl/JobBuilder.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/dsl/JobBuilder.kt
@@ -2,12 +2,7 @@ package it.krzeminski.githubactions.dsl
 
 import it.krzeminski.githubactions.actions.Action
 import it.krzeminski.githubactions.actions.ActionWithOutputs
-import it.krzeminski.githubactions.domain.CommandStep
-import it.krzeminski.githubactions.domain.Concurrency
-import it.krzeminski.githubactions.domain.ExternalActionStep
-import it.krzeminski.githubactions.domain.ExternalActionStepWithOutputs
-import it.krzeminski.githubactions.domain.Job
-import it.krzeminski.githubactions.domain.RunnerType
+import it.krzeminski.githubactions.domain.*
 
 @Suppress("LongParameterList")
 @GithubActionsDsl
@@ -15,6 +10,7 @@ class JobBuilder(
     val id: String,
     val name: String?,
     val runsOn: RunnerType,
+    val defaults: Defaults? = null,
     val needs: List<Job>,
     val env: LinkedHashMap<String, String>,
     val condition: String?,
@@ -27,6 +23,7 @@ class JobBuilder(
         id = id,
         name = name,
         runsOn = runsOn,
+        defaults = defaults,
         needs = needs,
         condition = condition,
         env = env,

--- a/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
@@ -1,9 +1,6 @@
 package it.krzeminski.githubactions.dsl
 
-import it.krzeminski.githubactions.domain.Concurrency
-import it.krzeminski.githubactions.domain.Job
-import it.krzeminski.githubactions.domain.RunnerType
-import it.krzeminski.githubactions.domain.Workflow
+import it.krzeminski.githubactions.domain.*
 import it.krzeminski.githubactions.domain.triggers.Trigger
 import java.nio.file.Path
 
@@ -15,6 +12,7 @@ class WorkflowBuilder(
     env: LinkedHashMap<String, String> = linkedMapOf(),
     sourceFile: Path,
     targetFileName: String,
+    defaults: Defaults? = null,
     concurrency: Concurrency? = null,
     jobs: List<Job> = emptyList(),
     _customArguments: Map<String, CustomValue>,
@@ -26,6 +24,7 @@ class WorkflowBuilder(
         sourceFile = sourceFile,
         targetFileName = targetFileName,
         jobs = jobs,
+        defaults = defaults,
         concurrency = concurrency,
         _customArguments = _customArguments,
     )
@@ -87,6 +86,7 @@ fun workflow(
     env: LinkedHashMap<String, String> = linkedMapOf(),
     sourceFile: Path,
     targetFileName: String = sourceFile.fileName.toString().substringBeforeLast(".main.kts") + ".yaml",
+    defaults: Defaults? = null,
     concurrency: Concurrency? = null,
     _customArguments: Map<String, CustomValue> = mapOf(),
     block: WorkflowBuilder.() -> Unit,
@@ -95,12 +95,17 @@ fun workflow(
         "There are no triggers defined!"
     }
 
+    defaults?.let {
+        defaults.run.requireAtLeastOneInput()
+    }
+
     val workflowBuilder = WorkflowBuilder(
         name = name,
         on = on,
         env = env,
         sourceFile = sourceFile,
         targetFileName = targetFileName,
+        defaults = defaults,
         concurrency = concurrency,
         _customArguments = _customArguments,
     )
@@ -112,6 +117,12 @@ fun workflow(
     workflowBuilder.workflow.jobs.requireUniqueJobIds()
 
     return workflowBuilder.build()
+}
+
+private fun Run.requireAtLeastOneInput() {
+    require(this.shell != null || this.workingDirectory != null) {
+        "At least one of shell or working-directory must be defined!"
+    }
 }
 
 private fun List<Job>.requireUniqueJobIds() {

--- a/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
@@ -34,6 +34,7 @@ class WorkflowBuilder(
         id: String,
         name: String? = null,
         runsOn: RunnerType,
+        defaults: Defaults? = null,
         needs: List<Job> = emptyList(),
         condition: String? = null,
         env: LinkedHashMap<String, String> = linkedMapOf(),
@@ -47,6 +48,7 @@ class WorkflowBuilder(
             id = id,
             name = name,
             runsOn = runsOn,
+            defaults = defaults,
             needs = needs,
             condition = condition,
             env = env,
@@ -117,12 +119,6 @@ fun workflow(
     workflowBuilder.workflow.jobs.requireUniqueJobIds()
 
     return workflowBuilder.build()
-}
-
-private fun Run.requireAtLeastOneInput() {
-    require(this.shell != null || this.workingDirectory != null) {
-        "At least one of shell or working-directory must be defined!"
-    }
 }
 
 private fun List<Job>.requireUniqueJobIds() {

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/JobsToYaml.kt
@@ -25,6 +25,14 @@ private fun Job.toYaml() = buildString {
     job.name?.let {
         appendLine("  name: $it")
     }
+    job.defaults?.let { defaults ->
+        appendLine("  defaults:")
+        if (defaults.run.shell != null || defaults.run.workingDirectory != null) {
+            appendLine("    run:")
+            defaults.run.shell?.let { appendLine("      shell: $it") }
+            defaults.run.workingDirectory?.let { appendLine("      working-directory: \"$it\"") }
+        }
+    }
     appendLine("  runs-on: \"${runsOn.toYaml()}\"")
     if (concurrency != null) {
         appendLine("  concurrency:")

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -89,6 +89,16 @@ private fun Workflow.generateYaml(addConsistencyCheck: Boolean, useGitDiff: Bool
         appendLine(workflow.on.triggersToYaml().prependIndent("  "))
         appendLine()
 
+        if (defaults != null) {
+            appendLine("defaults:")
+            if (defaults.run.shell != null || defaults.run.workingDirectory != null) {
+                appendLine("  run:")
+                defaults.run.shell?.let { appendLine("    shell: $it") }
+                defaults.run.workingDirectory?.let { appendLine("    working-directory: \"$it\"") }
+                appendLine()
+            }
+        }
+
         if (concurrency != null) {
             appendLine("concurrency:")
             appendLine("  group: ${concurrency.group}")

--- a/library/src/test/kotlin/it/krzeminski/githubactions/domain/JobTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/domain/JobTest.kt
@@ -17,7 +17,7 @@ class JobTest : FunSpec({
             "job()"
         ).forAll { jobId ->
             shouldThrowAny {
-                Job(jobId, null, RunnerType.UbuntuLatest, emptyList())
+                Job(jobId, null, RunnerType.UbuntuLatest, null, emptyList())
             }.shouldHaveMessage(
                 """
                 Invalid field Job(id="$jobId") does not match regex: [a-zA-Z_][a-zA-Z0-9_-]*
@@ -36,7 +36,7 @@ class JobTest : FunSpec({
             "JOB_JOB",
             "_--4",
         ).forAll { jobName ->
-            Job(jobName, null, RunnerType.UbuntuLatest, emptyList())
+            Job(jobName, null, RunnerType.UbuntuLatest, null, emptyList())
         }
     }
 
@@ -55,5 +55,22 @@ class JobTest : FunSpec({
                 ),
             )
         } shouldHaveMessage "timeout should be positive"
+    }
+
+    test("should reject defaults with no run parameters") {
+        shouldThrowAny {
+            Job(
+                id = "Job-1",
+                runsOn = RunnerType.UbuntuLatest,
+                steps = listOf(
+                    CommandStep(
+                        id = "someId",
+                        name = "Some command",
+                        command = "echo 'test!'",
+                    ),
+                ),
+                defaults = Defaults(run = Run()),
+            )
+        } shouldHaveMessage "Run should at least have one of shell or working-directory defined!"
     }
 })

--- a/library/src/test/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilderTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilderTest.kt
@@ -213,7 +213,7 @@ class WorkflowBuilderTest : FunSpec({
                     }
                 }
             }
-            exception.message shouldBe "At least one of shell or working-directory must be defined!"
+            exception.message shouldBe "Run should at least have one of shell or working-directory defined!"
         }
     }
 })

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/GitHubWorkflow.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/GitHubWorkflow.kt
@@ -5,6 +5,8 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.asClassName
 import it.krzeminski.githubactions.domain.Concurrency
+import it.krzeminski.githubactions.domain.Defaults
+import it.krzeminski.githubactions.domain.Run
 import it.krzeminski.githubactions.domain.Workflow
 import it.krzeminski.githubactions.scriptmodel.YamlWorkflow
 import it.krzeminski.githubactions.wrappergenerator.generation.toPascalCase
@@ -28,6 +30,7 @@ fun YamlWorkflow.workFlowProperty(filenameFromUrl: String?): PropertySpec {
                     .add("on = %L", on.toKotlin())
                     .add("sourceFile = %T.get(%S),\n", Paths::class, Paths.get(".github/workflows/$filename.main.kts"))
                     .add(workflowEnv())
+                    .add(defaultsOf(defaults))
                     .add(concurrencyOf(concurrency))
                     .unindent()
                     .add(") {\n")
@@ -38,6 +41,17 @@ fun YamlWorkflow.workFlowProperty(filenameFromUrl: String?): PropertySpec {
             }
         )
         .build()
+}
+
+fun defaultsOf(defaults: Defaults?): CodeBlock = when (defaults) {
+    null -> CodeBlock.EMPTY
+    else -> CodeBlock.of(
+        "defaults = %T(run = %T(shell = %S, workingDirectory = %S),\n",
+        Defaults::class.asClassName(),
+        Run::class.asClassName(),
+        defaults.run.shell,
+        defaults.run.workingDirectory,
+    )
 }
 
 fun concurrencyOf(concurrency: Concurrency?): CodeBlock = when (concurrency) {

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/Jobs.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptgenerator/Jobs.kt
@@ -19,6 +19,7 @@ fun YamlWorkflow.generateJobs() = CodeBlock { builder ->
         if (job.name != null) builder.add("name = %S,\n", job.name)
         builder.add(runnerTypeBlockOf(job.runsOn))
         builder.add(concurrencyOf(job.concurrency))
+        builder.add(defaultsOf(job.defaults))
         builder.add(
             job.env.joinToCode(
                 ifEmpty = CodeBlock.EMPTY,

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptmodel/YamlJob.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptmodel/YamlJob.kt
@@ -1,6 +1,7 @@
 package it.krzeminski.githubactions.scriptmodel
 
 import it.krzeminski.githubactions.domain.Concurrency
+import it.krzeminski.githubactions.domain.Defaults
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,6 +10,7 @@ data class YamlJob(
     val name: String? = null,
     @SerialName("runs-on")
     val runsOn: String,
+    val defaults: Defaults? = null,
     val steps: List<YamlStep>,
     val needs: List<String> = emptyList(),
     val env: LinkedHashMap<String, String> = linkedMapOf(),

--- a/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptmodel/YamlWorkflow.kt
+++ b/script-generator/src/main/kotlin/it/krzeminski/githubactions/scriptmodel/YamlWorkflow.kt
@@ -1,12 +1,14 @@
 package it.krzeminski.githubactions.scriptmodel
 
 import it.krzeminski.githubactions.domain.Concurrency
+import it.krzeminski.githubactions.domain.Defaults
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class YamlWorkflow(
     val name: String,
     val on: YamlWorkflowTriggers,
+    val defaults: Defaults? = null,
     val concurrency: Concurrency? = null,
     val jobs: Map<String, YamlJob> = emptyMap(),
     val env: Map<String, String> = emptyMap(),


### PR DESCRIPTION
This adds support for [defaults parameters](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaults) on both the workflow and job levels.

One thing to note, I couldn't run the tests located in `script-generator/src/test/kotlin/test/GenerateKotlinScripts.kt`. It produces the following error:

```bash
Execution failed for task ':script-generator:test'.
> No tests found for given includes: [test.GenerateKotlinScripts](--tests filter)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```

I was able to run all other tests without an issue.

I haven't touched Kotlin since the very early days of its release, so I tried to my best to follow the standards set by other areas of the code base.

Implements #347 