### PR TITLE
Decouple the library version and the recommended script-generator version

### DIFF
--- a/docs/user-guide/script-generator.md
+++ b/docs/user-guide/script-generator.md
@@ -7,7 +7,7 @@ when you want to save time on migrating your workflows to YAML.
 To use it, clone the repository locally, in a version corresponding to the latest released version of the library:
 
 ```bash
-git clone -b v[[ scriptGenerator ]] https://github.com/krzema12/github-actions-kotlin-dsl
+git clone -b v[[ scriptGeneratorVersion ]] https://github.com/krzema12/github-actions-kotlin-dsl
 cd github-actions-kotlin-dsl
 ```
 

--- a/docs/user-guide/script-generator.md
+++ b/docs/user-guide/script-generator.md
@@ -7,7 +7,7 @@ when you want to save time on migrating your workflows to YAML.
 To use it, clone the repository locally, in a version corresponding to the latest released version of the library:
 
 ```bash
-git clone -b v[[ version ]] https://github.com/krzema12/github-actions-kotlin-dsl
+git clone -b v[[ scriptGenerator ]] https://github.com/krzema12/github-actions-kotlin-dsl
 cd github-actions-kotlin-dsl
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,3 +48,6 @@ nav:
 
 extra:
   version: 0.23.0
+
+  # branch or tag name - the script-generator may have not yet updated to a breaking change in the library
+  scriptGenerator: 0.22.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,4 +50,4 @@ extra:
   version: 0.23.0
 
   # branch or tag name - the script-generator may have not yet updated to a breaking change in the library
-  scriptGenerator: 0.22.0
+  scriptGeneratorVersion: 0.22.0


### PR DESCRIPTION
**What?**

Decouple the latest library version from the recommended script-generator version in the doc at
https://krzema12.github.io/github-actions-kotlin-dsl/user-guide/script-generator/

**Why?**

There may be a breaking change when the library is released.

Coupling both versions

- prevents Piotr from releasing freely
- put some pression on me to adapt the script-generator ASAP

Since the script-generator still works fine in the previously validated version, and updating the library is pretty easy once the script is generated, this coupling is not necessary.

**How?**

New markdown variable