### PR TITLE
chore: extract common build logic to a local Gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.7.10" apply false
-    kotlin("plugin.serialization") version "1.7.10" apply false
-
-    // Code quality.
-    id("io.gitlab.arturbosch.detekt") version "1.21.0" apply false
-    id("org.jlleitschuh.gradle.ktlint") version "10.3.0" apply false
+    base
 
     // Publishing.
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0" // Needs to be applied to the root project.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    `kotlin-dsl`
+    kotlin("jvm") version embeddedKotlinVersion
+}
+
+dependencies {
+    implementation(enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:1.7.10"))
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
+    implementation("org.jetbrains.kotlin:kotlin-serialization")
+
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")
+    implementation("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")
+}

--- a/buildSrc/repositories.settings.gradle.kts
+++ b/buildSrc/repositories.settings.gradle.kts
@@ -1,0 +1,16 @@
+// A settings.gradle.kts plugin for defining shared repositories used by both buildSrc and the root project
+
+@Suppress("UnstableApiUsage") // centralised repository definitions are incubating
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    pluginManagement {
+        repositories {
+            gradlePluginPortal()
+            mavenCentral()
+        }
+    }
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "buildSrc"
+
+apply(from = "./repositories.settings.gradle.kts")

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -1,0 +1,47 @@
+package buildsrc.convention
+
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm")
+    `java-library`
+
+    // Code quality.
+    id("org.jlleitschuh.gradle.ktlint")
+}
+
+dependencies {
+    testImplementation(platform("io.kotest:kotest-bom:5.4.1"))
+    testImplementation("io.kotest:kotest-assertions-core")
+    testImplementation("io.kotest:kotest-runner-junit5")
+}
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        apiVersion = "1.5"
+        languageVersion = "1.7"
+        jvmTarget = "11"
+
+        allWarningsAsErrors = true
+
+        freeCompilerArgs += listOf(
+            "-opt-in=kotlin.ExperimentalStdlibApi",
+            "-opt-in=kotlin.time.ExperimentalTime",
+        )
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -9,12 +9,12 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 
 plugins {
-    kotlin("jvm")
+    buildsrc.convention.`kotlin-jvm`
+
     kotlin("plugin.serialization")
 
     // Code quality.
     id("io.gitlab.arturbosch.detekt")
-    id("org.jlleitschuh.gradle.ktlint")
 
     // Publishing.
     `maven-publish`
@@ -24,18 +24,11 @@ plugins {
 group = "it.krzeminski"
 version = "0.23.0"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation("com.charleskorn.kaml:kaml:0.46.0")
     implementation("org.yaml:snakeyaml:1.30")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.3.3")
 
-    testImplementation(platform("io.kotest:kotest-bom:5.4.1"))
-    testImplementation("io.kotest:kotest-assertions-core")
-    testImplementation("io.kotest:kotest-runner-junit5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
     testImplementation(kotlin("reflect"))
 }
@@ -50,21 +43,10 @@ sourceSets {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "11"
-        allWarningsAsErrors = true
         freeCompilerArgs += listOf(
             "-opt-in=it.krzeminski.githubactions.internal.InternalGithubActionsApi"
         )
     }
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
-
-java {
-    withJavadocJar()
-    withSourcesJar()
 }
 
 ktlint {

--- a/script-generator/build.gradle.kts
+++ b/script-generator/build.gradle.kts
@@ -1,16 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm")
+    buildsrc.convention.`kotlin-jvm`
+
     kotlin("plugin.serialization")
+
     application
-
-    // Code quality.
-    id("org.jlleitschuh.gradle.ktlint")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -19,14 +14,6 @@ dependencies {
     implementation("com.charleskorn.kaml:kaml:0.46.0")
     implementation("com.squareup:kotlinpoet:1.12.0")
     implementation(kotlin("reflect"))
-
-    testImplementation(platform("io.kotest:kotest-bom:5.4.1"))
-    testImplementation("io.kotest:kotest-assertions-core")
-    testImplementation("io.kotest:kotest-runner-junit5")
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
 }
 
 application {
@@ -42,8 +29,6 @@ ktlint {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "11"
-        allWarningsAsErrors = true
         freeCompilerArgs += listOf(
             "-opt-in=it.krzeminski.githubactions.internal.InternalGithubActionsApi"
         )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "github-actions-kotlin-dsl"
 
+apply(from = "./buildSrc/repositories.settings.gradle.kts")
+
 include(
     "library",
     "wrapper-generator",
@@ -8,6 +10,11 @@ include(
 
 plugins {
     id("com.gradle.enterprise").version("3.8.1")
+}
+
+dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage") // Central declaration of repositories is an incubating feature
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
 }
 
 gradleEnterprise {

--- a/wrapper-generator/build.gradle.kts
+++ b/wrapper-generator/build.gradle.kts
@@ -1,16 +1,9 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    kotlin("jvm")
+    buildsrc.convention.`kotlin-jvm`
+
     kotlin("plugin.serialization")
+
     application
-
-    // Code quality.
-    id("org.jlleitschuh.gradle.ktlint")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -19,14 +12,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
 
-    testImplementation(platform("io.kotest:kotest-bom:5.4.1"))
-    testImplementation("io.kotest:kotest-assertions-core")
-    testImplementation("io.kotest:kotest-runner-junit5")
     testImplementation(projects.library)
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
 }
 
 application {
@@ -46,12 +32,5 @@ tasks.register<JavaExec>("suggestVersions") {
 ktlint {
     filter {
         exclude("**/wrappersfromunittests/**")
-    }
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "11"
-        allWarningsAsErrors = true
     }
 }


### PR DESCRIPTION
This change incorporates a part of this PR: #194. Introducing in
smaller pieces to reduce blast radius if something goes wrong.