### PR TITLE
[#80] chore(library): remove unneeded dependency on kaml

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -14,7 +14,6 @@ group = "it.krzeminski"
 version = "0.24.0"
 
 dependencies {
-    implementation("com.charleskorn.kaml:kaml:0.46.0")
     implementation("org.yaml:snakeyaml:1.30")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.3.3")
 


### PR DESCRIPTION
In the previous approach for YAML emitting, it
was used to validate if the YAML is valid. Now
we intend to create the valid YAML right away,
so kaml usage was removed.