### PR TITLE
Bump com.gradle.enterprise plugin to 3.11.1

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ include(
 )
 
 plugins {
-    id("com.gradle.enterprise") version "3.8.1"
+    id("com.gradle.enterprise") version "3.11.1"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
https://plugins.gradle.org/plugin/com.gradle.enterprise

Not sure why this plugin hasn't been bumped by @renovate-bot.