### PR TITLE
[#416] fix(library)!: use event-based approach to emit YAML

### DIFF
--- a/.github/workflows/Integration tests - job condition.yaml
+++ b/.github/workflows/Integration tests - job condition.yaml
@@ -3,7 +3,7 @@
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
 name: Integration tests - job condition
-'on':
+on:
   push: {}
 jobs:
   test_job:

--- a/.github/workflows/Integration tests - multiline command with pipes.yaml
+++ b/.github/workflows/Integration tests - multiline command with pipes.yaml
@@ -3,7 +3,7 @@
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
 name: Integration tests - multiline command with pipes
-'on':
+on:
   push: {}
 jobs:
   test_job:

--- a/.github/workflows/Integration tests - one job depending on another.yaml
+++ b/.github/workflows/Integration tests - one job depending on another.yaml
@@ -3,7 +3,7 @@
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
 name: Integration tests - one job depending on another
-'on':
+on:
   push: {}
 jobs:
   test_job_1:

--- a/.github/workflows/Integration tests - step with outputs.yaml
+++ b/.github/workflows/Integration tests - step with outputs.yaml
@@ -3,7 +3,7 @@
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
 name: Integration tests - step with outputs
-'on':
+on:
   push: {}
 jobs:
   test_job:

--- a/.github/workflows/Integration tests - trivial workflow.yaml
+++ b/.github/workflows/Integration tests - trivial workflow.yaml
@@ -3,7 +3,7 @@
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
 name: Integration tests - trivial workflow
-'on':
+on:
   push: {}
 jobs:
   test_job:

--- a/.github/workflows/Integration tests - type-safe expressions.yaml
+++ b/.github/workflows/Integration tests - type-safe expressions.yaml
@@ -3,7 +3,7 @@
 # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
 name: Integration tests - type-safe expressions
-'on':
+on:
   push: {}
 jobs:
   job1:

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -14,7 +14,7 @@ group = "it.krzeminski"
 version = "0.25.0"
 
 dependencies {
-    implementation("org.yaml:snakeyaml:1.30")
+    implementation("org.snakeyaml:snakeyaml-engine:2.3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.4.0")
 
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ObjectToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ObjectToYaml.kt
@@ -1,12 +1,89 @@
 package it.krzeminski.githubactions.yaml
 
-import org.yaml.snakeyaml.DumperOptions
-import org.yaml.snakeyaml.Yaml
+import org.snakeyaml.engine.v2.api.DumpSettings
+import org.snakeyaml.engine.v2.api.StreamDataWriter
+import org.snakeyaml.engine.v2.common.FlowStyle
+import org.snakeyaml.engine.v2.common.ScalarStyle
+import org.snakeyaml.engine.v2.emitter.Emitter
+import org.snakeyaml.engine.v2.events.DocumentEndEvent
+import org.snakeyaml.engine.v2.events.DocumentStartEvent
+import org.snakeyaml.engine.v2.events.ImplicitTuple
+import org.snakeyaml.engine.v2.events.MappingEndEvent
+import org.snakeyaml.engine.v2.events.MappingStartEvent
+import org.snakeyaml.engine.v2.events.ScalarEvent
+import org.snakeyaml.engine.v2.events.SequenceEndEvent
+import org.snakeyaml.engine.v2.events.SequenceStartEvent
+import org.snakeyaml.engine.v2.events.StreamEndEvent
+import org.snakeyaml.engine.v2.events.StreamStartEvent
+import java.io.StringWriter
+import java.util.Optional
 
-internal fun Any.toYaml(): String = yaml.dump(this)
-
-private val yaml = Yaml(
-    DumperOptions().apply {
-        defaultFlowStyle = DumperOptions.FlowStyle.BLOCK
+internal fun Any.toYaml(): String {
+    val settings = DumpSettings.builder()
+        .build()
+    val writer = object : StringWriter(), StreamDataWriter {
+        override fun flush() {
+            // no-op
+        }
     }
-)
+    val emitter = Emitter(settings, writer)
+    emitter.emit(StreamStartEvent())
+    emitter.emit(DocumentStartEvent(false, Optional.empty(), emptyMap()))
+
+    this.elementToYaml(emitter)
+
+    emitter.emit(DocumentEndEvent(false))
+    emitter.emit(StreamEndEvent())
+    return writer.toString()
+}
+
+private fun Any?.elementToYaml(emitter: Emitter) {
+    when (this) {
+        is Map<*, *> -> this.mapToYaml(emitter)
+        is List<*> -> this.listToYaml(emitter)
+        is String, is Int, is Float, is Boolean, null -> this.scalarToYaml(emitter)
+        else -> error("Serializing $this is not supported!")
+    }
+}
+
+private fun Map<*, *>.mapToYaml(emitter: Emitter) {
+    emitter.emit(MappingStartEvent(Optional.empty(), Optional.empty(), true, FlowStyle.BLOCK))
+
+    this.forEach { (key, value) ->
+        // key
+        emitter.emit(
+            ScalarEvent(
+                Optional.empty(),
+                Optional.empty(),
+                ImplicitTuple(true, true),
+                key.toString(),
+                ScalarStyle.PLAIN,
+            ),
+        )
+        // value
+        value.elementToYaml(emitter)
+    }
+
+    emitter.emit(MappingEndEvent())
+}
+
+private fun List<*>.listToYaml(emitter: Emitter) {
+    emitter.emit(SequenceStartEvent(Optional.empty(), Optional.empty(), true, FlowStyle.BLOCK))
+
+    this.forEach { value ->
+        value.elementToYaml(emitter)
+    }
+
+    emitter.emit(SequenceEndEvent())
+}
+
+private fun Any?.scalarToYaml(emitter: Emitter) {
+    val scalarStyle = if (this is String && this.lines().size > 1) {
+        ScalarStyle.LITERAL
+    } else {
+        ScalarStyle.PLAIN
+    }
+    emitter.emit(
+        ScalarEvent(Optional.empty(), Optional.empty(), ImplicitTuple(true, true), this.toString(), scalarStyle),
+    )
+}

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -49,7 +49,7 @@ class IntegrationTest : FunSpec({
             # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
             name: Test workflow
-            'on':
+            on:
               push: {}
             jobs:
               check_yaml_consistency:
@@ -112,7 +112,7 @@ class IntegrationTest : FunSpec({
             # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
             name: Test workflow
-            'on':
+            on:
               push: {}
             jobs:
               test_job:
@@ -200,7 +200,7 @@ class IntegrationTest : FunSpec({
             # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
             name: Test workflow
-            'on':
+            on:
               push: {}
             jobs:
               check_yaml_consistency:
@@ -314,7 +314,7 @@ class IntegrationTest : FunSpec({
             # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
             name: Overridden name!
-            'on':
+            on:
               push: {}
             env:
               SIMPLE_VAR: simple-value-workflow
@@ -410,7 +410,7 @@ class IntegrationTest : FunSpec({
             # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
             name: Test workflow
-            'on':
+            on:
               push: {}
             concurrency:
               group: workflow_staging_environment
@@ -468,7 +468,7 @@ class IntegrationTest : FunSpec({
             # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
 
             name: Test workflow
-            'on':
+            on:
               push: {}
             concurrency:
               group: workflow_staging_environment

--- a/library/src/test/kotlin/it/krzeminski/githubactions/yaml/ObjectToYamlTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/yaml/ObjectToYamlTest.kt
@@ -73,12 +73,10 @@ class ObjectToYamlTest : DescribeSpec({
         val yaml = objectToSerialize.toYaml()
 
         // then
-        // Using anchors is not desired. This test presents the current undesired behavior.
-        // To be fixed in scope of https://github.com/krzema12/github-actions-kotlin-dsl/issues/416
         yaml shouldBe """
-            foo: &id001 {}
-            bar: *id001
-            baz: *id001
+            foo: {}
+            bar: {}
+            baz: {}
 
         """.trimIndent()
     }


### PR DESCRIPTION
The main motivator for this change is being able to not produce anchors
which are not supported by GitHub. Apart from that, this approach gives
us great control over the produced YAML.