### PR TITLE
[#428] feat(library): add ability to conditionally run consistency job

### DIFF
--- a/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/domain/Workflow.kt
@@ -12,6 +12,7 @@ data class Workflow(
     val sourceFile: Path,
     val targetFileName: String,
     val concurrency: Concurrency? = null,
+    val yamlConsistencyJobCondition: String? = null,
     val jobs: List<Job>,
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
 ) : HasCustomArguments

--- a/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/dsl/WorkflowBuilder.kt
@@ -17,6 +17,7 @@ class WorkflowBuilder(
     sourceFile: Path,
     targetFileName: String,
     concurrency: Concurrency? = null,
+    yamlConsistencyJobCondition: String? = null,
     jobs: List<Job> = emptyList(),
     _customArguments: Map<String, @Contextual Any>,
 ) {
@@ -28,6 +29,7 @@ class WorkflowBuilder(
         targetFileName = targetFileName,
         jobs = jobs,
         concurrency = concurrency,
+        yamlConsistencyJobCondition = yamlConsistencyJobCondition,
         _customArguments = _customArguments,
     )
 
@@ -89,6 +91,7 @@ fun workflow(
     sourceFile: Path,
     targetFileName: String = sourceFile.fileName.toString().substringBeforeLast(".main.kts") + ".yaml",
     concurrency: Concurrency? = null,
+    yamlConsistencyJobCondition: String? = null,
     _customArguments: Map<String, @Contextual Any> = mapOf(),
     block: WorkflowBuilder.() -> Unit,
 ): Workflow {
@@ -103,6 +106,7 @@ fun workflow(
         sourceFile = sourceFile,
         targetFileName = targetFileName,
         concurrency = concurrency,
+        yamlConsistencyJobCondition = yamlConsistencyJobCondition,
         _customArguments = _customArguments,
     )
     workflowBuilder.block()

--- a/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/it/krzeminski/githubactions/yaml/ToYaml.kt
@@ -43,6 +43,7 @@ private fun Workflow.generateYaml(addConsistencyCheck: Boolean, useGitDiff: Bool
         val consistencyCheckJob = this.toBuilder().job(
             id = "check_yaml_consistency",
             runsOn = UbuntuLatest,
+            condition = yamlConsistencyJobCondition,
         ) {
             uses("Check out", CheckoutV3())
             if (useGitDiff) {

--- a/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
+++ b/library/src/test/kotlin/it/krzeminski/githubactions/IntegrationTest.kt
@@ -540,6 +540,59 @@ class IntegrationTest : FunSpec({
             }
         }
     }
+
+    test("toYaml() - YAML consistency job condition") {
+        // when
+        val actualYaml =
+            workflow(
+                name = "Test workflow",
+                on = listOf(Push()),
+                yamlConsistencyJobCondition = "\${{ always() }}",
+                sourceFile = gitRootDir.resolve(".github/workflows/some_workflow.main.kts"),
+            ) {
+                job(
+                    id = "test_job",
+                    name = "Test Job",
+                    runsOn = RunnerType.UbuntuLatest,
+                ) {
+                    uses(CheckoutV3())
+                    run("echo 'hello!'")
+                }
+            }.toYaml()
+
+        // then
+        actualYaml shouldBe """
+            # This file was generated using Kotlin DSL (.github/workflows/some_workflow.main.kts).
+            # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+            # Generated with https://github.com/krzema12/github-actions-kotlin-dsl
+
+            name: Test workflow
+            on:
+              push: {}
+            jobs:
+              check_yaml_consistency:
+                runs-on: ubuntu-latest
+                if: ${'$'}{{ always() }}
+                steps:
+                - id: step-0
+                  name: Check out
+                  uses: actions/checkout@v3
+                - id: step-1
+                  name: Consistency check
+                  run: diff -u '.github/workflows/some_workflow.yaml' <('.github/workflows/some_workflow.main.kts')
+              test_job:
+                name: Test Job
+                runs-on: ubuntu-latest
+                needs:
+                - check_yaml_consistency
+                steps:
+                - id: step-0
+                  uses: actions/checkout@v3
+                - id: step-1
+                  run: echo 'hello!'
+
+        """.trimIndent()
+    }
 })
 
 private fun testRanWithGitHub(


### PR DESCRIPTION
Sometimes it's desired to run the whole workflow conditionally. Before
this change, it was only possible to define conditons for jobs defined
by the user. After this change, it's also possible to conditionally
disable the consistency job, so effectively it will be possible to omit
running the whole workflow.